### PR TITLE
Fix null Attachment to return empty Array

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -567,6 +567,8 @@ public class ModelResourceImpl implements ModelResource {
 					   : query.setParameters(Integer.parseInt(id)).first();
 		if (po != null) {
 			MAttachment attachment = po.getAttachment();
+			if(attachment == null)
+				return Response.ok(array.toString()).build();
 			for(MAttachmentEntry entry : attachment.getEntries()) {
 				JsonObject entryJsonObject = new JsonObject();
 				entryJsonObject.addProperty("name", entry.getName());


### PR DESCRIPTION
Return Empty Array when getting all attachments from Record which does not have any attachments.