### PR TITLE
Fix Missing Process Instance values

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/Process.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/Process.java
@@ -145,6 +145,9 @@ public class Process {
 			}
 		}
 		
+		//Save Process Instance
+		pInstance.saveEx();
+
 		return pInstance;
 	}
 	


### PR DESCRIPTION
Process Instance did not save RunAsJob Parameter when process was set to Run as Job.

Save Process instance on the end of createPInstance method.

