### PR TITLE
Issue #61 Improvements to allow integration with krakend

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/AuthService.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/AuthService.java
@@ -109,4 +109,13 @@ public interface AuthService {
 	 * @return new auth token
 	 */
 	public Response changeLoginParameters(LoginParameters loginRole);
+
+	@Path("auth/jwk")
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	/**
+	 * Get JWK
+	 * @return jwk keys
+	 */
+	public Response getJWK();
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
@@ -74,6 +74,9 @@ public class RequestFilter implements ContainerRequestFilter {
 			|| (   HttpMethod.POST.equals(requestContext.getMethod())
 				&& requestContext.getUriInfo().getPath().endsWith("v1/auth/tokens")
 				)
+			|| (   HttpMethod.GET.equals(requestContext.getMethod())
+					&& requestContext.getUriInfo().getPath().endsWith("v1/auth/jwk")
+					)
 			) {
 			return;
 		}
@@ -101,7 +104,7 @@ public class RequestFilter implements ContainerRequestFilter {
 	}
 
 	private void validate(String token) throws IllegalArgumentException, UnsupportedEncodingException {
-		Algorithm algorithm = Algorithm.HMAC256(TokenUtils.getTokenSecret());
+		Algorithm algorithm = Algorithm.HMAC512(TokenUtils.getTokenSecret());
 		JWTVerifier verifier = JWT.require(algorithm)
 		        .withIssuer(TokenUtils.getTokenIssuer())
 		        .build(); //Reusable verifier instance

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/jwt/ITokenSecretProvider.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/jwt/ITokenSecretProvider.java
@@ -36,4 +36,13 @@ public interface ITokenSecretProvider {
 	 * @return token secret
 	 */
 	public String getSecret();
+
+	public default String getKeyId() {
+		return "idempiere";
+	}
+
+	public default String getIssuer() {
+		return "idempiere.org";
+	}
+
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/jwt/TokenUtils.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/jwt/TokenUtils.java
@@ -53,11 +53,27 @@ public class TokenUtils {
 	}
 
 	/**
+	 *
+	 * @return token key id
+	 */
+	public static String getTokenKeyId() {
+		ITokenSecretProvider provider = Service.locator().locate(ITokenSecretProvider.class).getService();
+		if (provider != null) {
+			return provider.getKeyId();
+		}
+		return DefaultTokenSecretProvider.instance.getKeyId();
+	}
+
+	/**
 	 * 
 	 * @return issuer of token
 	 */
 	public static String getTokenIssuer() {
-		return "idempiere.org";
+		ITokenSecretProvider provider = Service.locator().locate(ITokenSecretProvider.class).getService();
+		if (provider != null) {
+			return provider.getIssuer();
+		}
+		return DefaultTokenSecretProvider.instance.getIssuer();
 	}
 
 	/**


### PR DESCRIPTION
* HS512 signature instead of HS256
* add TokenKeyId information to the token
* issuer and keyId configurable in the ITokenSecretProvider
* create a new endpoint for /api/v1/auth/jwk (requires SysConfig IDEMPIERE_REST_EXPOSE_JWK=Y to enable)