### PR TITLE
Add print document from model api/v1/models/{tableName}/{id}/print

### DIFF
--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -1882,6 +1882,46 @@
 			"response": []
 		},
 		{
+			"name": "api/v1/models/{tableName}/{id}/print",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "Accept",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"type": "text",
+						"value": "Bearer {{authToken}}"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_order/102/print",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_order",
+						"102",
+						"print"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/windows/{window slug}/{recordid}/print",
 			"request": {
 				"method": "GET",

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
@@ -217,4 +217,16 @@ public interface ModelResource {
 	 * @return http response
 	 */
 	public Response deleteAttachmentEntry(@PathParam("tableName") String tableName, @PathParam("id") String id, @PathParam("fileName") String fileName);
+	
+	@Path("{tableName}/{id}/print")
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	/**
+	 * Print model record
+	 * @param tableName
+	 * @param id id/uuid
+	 * @param reportType print output type
+	 * @return json representation of record
+	 */
+	public Response printModelRecord(@PathParam("tableName") String tableName, @PathParam("id") String id, @QueryParam("$report_type") String reportType);
 }


### PR DESCRIPTION
We already have print document from window but often times we only have information in AD_Table_ID + Record_ID.
This pull request will add new endpoint in models that need only tableName and id as parameter, then it will search for suitable window based on that params, if the window is found it will then delegate the print doc process to existing api/v1/windows/{window slug}/{recordid}/print