### PR TITLE
Implement health check endpoint

### DIFF
--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -7,6 +7,34 @@
 	},
 	"item": [
 		{
+			"name": "api/v1/health",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/health",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"health"
+					]
+				},
+				"description": "Get health status"
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/auth/tokens",
 			"event": [
 				{

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/ApplicationV1.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/ApplicationV1.java
@@ -38,6 +38,7 @@ import com.trekglobal.idempiere.rest.api.v1.auth.impl.AuthServiceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.CacheResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.FileResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.FormResourceImpl;
+import com.trekglobal.idempiere.rest.api.v1.resource.impl.HealthResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.InfoResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.ModelResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.NodeResourceImpl;
@@ -78,6 +79,7 @@ public class ApplicationV1 extends Application {
         classes.add(ServerResourceImpl.class);
         classes.add(InfoResourceImpl.class);
         classes.add(WorkflowResourceImpl.class);
+        classes.add(HealthResourceImpl.class);
         
         return classes;
     }	

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
@@ -78,6 +78,9 @@ public class RequestFilter implements ContainerRequestFilter {
 			|| (   HttpMethod.GET.equals(requestContext.getMethod())
 					&& requestContext.getUriInfo().getPath().endsWith("v1/auth/jwk")
 					)
+			|| (   HttpMethod.GET.equals(requestContext.getMethod())
+					&& requestContext.getUriInfo().getPath().endsWith("v1/health")
+				)
 			) {
 			return;
 		}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
@@ -1,0 +1,47 @@
+/**********************************************************************
+* This file is part of iDempiere ERP Open Source                      *
+* http://www.idempiere.org                                            *
+*                                                                     *
+* Copyright (C) Contributors                                          *
+*                                                                     *
+* This program is free software; you can redistribute it and/or       *
+* modify it under the terms of the GNU General Public License         *
+* as published by the Free Software Foundation; either version 2      *
+* of the License, or (at your option) any later version.              *
+*                                                                     *
+* This program is distributed in the hope that it will be useful,     *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+* GNU General Public License for more details.                        *
+*                                                                     *
+* You should have received a copy of the GNU General Public License   *
+* along with this program; if not, write to the Free Software         *
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+* MA 02110-1301, USA.                                                 *
+*                                                                     *
+**********************************************************************/
+package com.trekglobal.idempiere.rest.api.v1.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * 
+ * @author Anozi Mada
+ *
+ */
+@Path("v1/health")
+public interface HealthResource {
+
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	/**
+	 * Get health status
+	 * @return response
+	 */
+	public Response health();
+
+}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
@@ -1,0 +1,58 @@
+/**********************************************************************
+* This file is part of iDempiere ERP Open Source                      *
+* http://www.idempiere.org                                            *
+*                                                                     *
+* Copyright (C) Contributors                                          *
+*                                                                     *
+* This program is free software; you can redistribute it and/or       *
+* modify it under the terms of the GNU General Public License         *
+* as published by the Free Software Foundation; either version 2      *
+* of the License, or (at your option) any later version.              *
+*                                                                     *
+* This program is distributed in the hope that it will be useful,     *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+* GNU General Public License for more details.                        *
+*                                                                     *
+* You should have received a copy of the GNU General Public License   *
+* along with this program; if not, write to the Free Software         *
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+* MA 02110-1301, USA.                                                 *
+*                                                                     *
+**********************************************************************/
+package com.trekglobal.idempiere.rest.api.v1.resource.impl;
+
+import javax.ws.rs.core.Response;
+
+import org.compiere.util.DB;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.trekglobal.idempiere.rest.api.v1.resource.HealthResource;
+
+/**
+ * 
+ * @author Anozi Mada
+ *
+ */
+public class HealthResourceImpl implements HealthResource {
+	
+	public HealthResourceImpl() {
+	}
+
+	@Override
+	public Response health() {
+		JsonObject databaseCheck = new JsonObject();
+		databaseCheck.addProperty("name", "Database connection health check");
+		databaseCheck.addProperty("status", DB.isConnected() ? "UP" : "DOWN");
+		
+		JsonArray checks = new JsonArray();
+		checks.add(databaseCheck);
+		
+		JsonObject json = new JsonObject();
+		json.addProperty("status", "UP");
+		json.add("checks", checks);
+		
+		return Response.ok(json.toString()).header("Cache-Control", "no-cache").build();
+	}
+}


### PR DESCRIPTION
This PR will add endpoint api/v1/health to get the health status. 
It can be used as heartbeat and it's faster compare to request GET/HEAD to webui.
It also useful for checking if the target idempiere server support REST plugin without the need to authenticating first.