### PR TITLE
implemented support for IsUseUserOrgAccess flag in org validation

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/AuthServiceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/AuthServiceImpl.java
@@ -414,6 +414,9 @@ public class AuthServiceImpl implements AuthService {
 
 	private boolean isValidOrg(int orgId, int roleId, Login login) {
 		if (orgId >= 0) {
+			String userName = Env.getContext(Env.getCtx(), RequestFilter.LOGIN_NAME);
+			MUser user = MUser.get(Env.getCtx(), userName);
+			Env.setContext(Env.getCtx(), Env.AD_USER_ID, user.getAD_User_ID());
 			MRole role = MRole.get(Env.getCtx(), roleId);
 			KeyNamePair rolesKeyNamePair = new KeyNamePair(role.getAD_Role_ID(), role.getName());
 			KeyNamePair[] orgs = login.getOrgs(rolesKeyNamePair);


### PR DESCRIPTION
When flag IsUseUserOrgAccess is true in AD_Role, we can obtain correctly orgs calling GET /auth/organizations , but when trying to login with PUT /auth, 401 is returned, cause AD_USER_ID isn't in the context.