### PR TITLE
Not able to update a column to NULL using api/v1/models #178

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -141,8 +141,17 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				continue;
 			}
 			Object value = TypeConverterUtils.fromJsonValue(column, field);
-			if (value != null)
+			if (value != null) {
+				if (value instanceof Integer) {
+					if (((Integer)value).intValue() < 0 && DisplayType.isID(column.getAD_Reference_ID())) {
+						value = null;
+					} else if (((Integer)value).intValue() == 0 && DisplayType.isLookup(column.getAD_Reference_ID())) {
+						if (! MTable.isZeroIDTable(column.getReferenceTableName()))
+							value = null;
+					}
+				}
 				po.set_ValueOfColumn(column.getAD_Column_ID(), value);
+			}
 		}
 		
 		return po;
@@ -181,8 +190,17 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			Object value = TypeConverterUtils.fromJsonValue(column, field);
-			if (value != null)
+			if (value != null) {
+				if (value instanceof Integer) {
+					if (((Integer)value).intValue() < 0 && DisplayType.isID(column.getAD_Reference_ID())) {
+						value = null;
+					} else if (((Integer)value).intValue() == 0 && DisplayType.isLookup(column.getAD_Reference_ID())) {
+						if (! MTable.isZeroIDTable(column.getReferenceTableName()))
+							value = null;
+					}
+				}
 				po.set_ValueOfColumn(column.getAD_Column_ID(), value);
+			}
 		}
 		
 		return po;


### PR DESCRIPTION
Able to set an ID column to NULL by passing in a negative value (e.g. -1) or 0 for a non-zero ID table

Request:
```
url: api/v1/models/C_BPartner/{{CreatedBPId}}
method: 'PUT'
body: '{ "C_Greeting_ID": { "id": "-1" } }'
```
or
```
url: api/v1/models/C_BPartner/{{CreatedBPId}}
method: 'PUT'
body: '{ "C_Greeting_ID": -1 }'
```
or
```
url: api/v1/models/C_BPartner/{{CreatedBPId}}
method: 'PUT'
body: '{ "C_Greeting_ID": { "id": "0" } }'
```
or
```
url: api/v1/models/C_BPartner/{{CreatedBPId}}
method: 'PUT'
body: '{ "C_Greeting_ID": 0 }'
```