### PR TITLE
Fixes for logout #209

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRefreshToken.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRefreshToken.java
@@ -46,6 +46,7 @@ public class MRefreshToken {
 	private final static String deleteSql = "DELETE FROM REST_RefreshToken WHERE ExpiresAt<getdate()";
 	private final static String deleteRefreshTokenSql = "DELETE FROM REST_RefreshToken WHERE RefreshToken = ?";
 	private final static String deleteTokenSql = "DELETE FROM REST_RefreshToken WHERE Token = ?";
+	private final static String selectWithTokenSql = "SELECT 1 FROM REST_RefreshToken WHERE Token = ?";
 
 	/**
 	 * Get an auth token based on a refresh token
@@ -152,6 +153,16 @@ public class MRefreshToken {
 	 */
 	public String getToken() {
 		return m_Token;
+	}
+
+	/**
+	 * Verify if there is a refresh token for a token
+	 * @param token
+	 * @return true if there is a refresh token
+	 */
+	public static boolean exists(String token) {
+		int one = DB.getSQLValueEx(null, selectWithTokenSql, token);
+		return one == 1;
 	}
 
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/process/ActiveInactiveToken.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/process/ActiveInactiveToken.java
@@ -22,6 +22,7 @@
 
 package com.trekglobal.idempiere.rest.api.process;
 
+import org.compiere.model.MSession;
 import org.compiere.process.SvrProcess;
 
 import com.trekglobal.idempiere.rest.api.model.MAuthToken;
@@ -44,7 +45,10 @@ public class ActiveInactiveToken extends SvrProcess {
 		MAuthToken token = new MAuthToken(getCtx(), getRecord_ID(), get_TrxName());
 		token.setIsActive(!token.isActive());		
 		token.saveEx();
-		
+
+		MSession sessionToken = new MSession(getCtx(), token.getAD_Session_ID(), get_TrxName());
+		sessionToken.logout();
+
 		return null;
 	}
 

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/AuthServiceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/AuthServiceImpl.java
@@ -652,7 +652,12 @@ public class AuthServiceImpl implements AuthService {
 					.entity(new ErrorBuilder().status(Status.NOT_FOUND).title("AD_Session_ID not found").build().toString())
 					.build();
 		}
-		Env.setContext(Env.getCtx(), "#AD_Session_ID", sessionId);
+		claim = jwt.getClaim(LoginClaims.AD_User_ID.name());
+		if (!claim.isNull() && !claim.isMissing()) {
+			int userId = claim.asInt();
+			Env.setContext(Env.getCtx(), Env.AD_USER_ID, userId);
+		}
+		Env.setContext(Env.getCtx(), Env.AD_SESSION_ID, sessionId);
 		MSession session = new MSession(Env.getCtx(), sessionId, null);
 		session.logout();
 


### PR DESCRIPTION
- the token validation is checking if the session was finished, but is possible that a session was finished on server restart so, this change verify if there is an auth token or a refresh token, that means the user has not logged auth and can keep using the token