### PR TITLE
ModelResourceImpl.createChild failed to get Java Model Class for the child table #307

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -481,7 +481,7 @@ public class ModelResourceImpl implements ModelResource {
 			}
 			MTable childTable = MTable.get(Env.getCtx(), childTableName);
 			if (childTable != null && childTable.getAD_Table_ID() > 0) {
-				IPOSerializer childSerializer = IPOSerializer.getPOSerializer(field, MTable.getClass(childTableName));
+				IPOSerializer childSerializer = IPOSerializer.getPOSerializer(childTableName, MTable.getClass(childTableName));
 				JsonArray fieldArray = fieldElement.getAsJsonArray();
 				JsonArray savedArray = new JsonArray();
 				try {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -481,7 +481,7 @@ public class ModelResourceImpl implements ModelResource {
 			}
 			MTable childTable = MTable.get(Env.getCtx(), childTableName);
 			if (childTable != null && childTable.getAD_Table_ID() > 0) {
-				IPOSerializer childSerializer = IPOSerializer.getPOSerializer(field, MTable.getClass(field));
+				IPOSerializer childSerializer = IPOSerializer.getPOSerializer(field, MTable.getClass(childTableName));
 				JsonArray fieldArray = fieldElement.getAsJsonArray();
 				JsonArray savedArray = new JsonArray();
 				try {


### PR DESCRIPTION
Issue:
I have a different naming in 'Rest View' window > 'Table' tab > 'Related Views' tab > 'Name' field. The 'Name' is not based on the table name. ModelResourceImpl.createChild failed to get Java Model Class for the child table based on the field name.

Solution:
Get Java Model Class for the child table based on the childTableName instead of field