### PR TITLE
Make mvn verify -DskipTests works with vanilla iDempiere database #349

### DIFF
--- a/com.trekglobal.idempiere.rest.api.test/META-INF/MANIFEST.MF
+++ b/com.trekglobal.idempiere.rest.api.test/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: com.trekglobal.idempiere.rest.api.test
 Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: TREKGLOBAL
 Automatic-Module-Name: com.trekglobal.extension.test
+Bundle-Activator: com.trekglobal.idempiere.rest.api.json.test.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: com.google.gson;version="[2.9.0,3.0.0]",
  javax.servlet.http;version="[3.1.0,4.0.0]",
@@ -24,6 +25,8 @@ Import-Package: com.google.gson;version="[2.9.0,3.0.0]",
  org.junit.jupiter.params.support;version="5.9.0",
  org.mockito,
  org.mockito.junit.jupiter,
- org.mockito.stubbing
+ org.mockito.stubbing,
+ org.osgi.framework;version="[1.10.0,2.0.0)",
+ org.osgi.util.tracker;version="[1.5.0,2.0.0)"
 Require-Bundle: org.adempiere.base;bundle-version="11.0.0",
  com.trekglobal.idempiere.rest.api;bundle-version="0.1.0"

--- a/com.trekglobal.idempiere.rest.api.test/pom.xml
+++ b/com.trekglobal.idempiere.rest.api.test/pom.xml
@@ -118,6 +118,11 @@
 								<versionRange>0.0.0</versionRange>
 							</requirement>
 							<requirement>
+                                                                <type>eclipse-plugin</type>
+                                                                <id>org.adempiere.pipo.handlers</id>
+                                                                <versionRange>0.0.0</versionRange>
+                                                        </requirement>
+							<requirement>
 								<type>eclipse-plugin</type>
 								<id>org.idempiere.hazelcast.service</id>
 								<versionRange>0.0.0</versionRange>

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/Activator.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/Activator.java
@@ -23,32 +23,26 @@
 * - Trek Global Corporation                                           *
 * - Heng Sin Low                                                      *
 **********************************************************************/
-package com.trekglobal.idempiere.rest.api;
+package com.trekglobal.idempiere.rest.api.json.test;
 
-import org.adempiere.base.Core;
-import org.adempiere.plugin.utils.Incremental2PackActivator;
+import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
-/**
- * 
- * @author hengsin
- *
- */
-public class Activator extends Incremental2PackActivator {
+public class Activator implements BundleActivator {
+
+	public static BundleContext context;
 	
+	public Activator() {
+	}
+
 	@Override
 	public void start(BundleContext context) throws Exception {
-		Core.getMappedModelFactory().scan(context, "com.trekglobal.idempiere.rest.api.model");
-		Core.getMappedProcessFactory().scan(context, "com.trekglobal.idempiere.rest.api.process");
-		Core.getMappedColumnCalloutFactory().scan(context, "com.trekglobal.idempiere.rest.api.model");
-
-		super.start(context);
+		Activator.context = context;
 	}
 
 	@Override
-	protected void afterPackIn() {
-		super.afterPackIn();
-		context.registerService(Activator.class, this, null);
+	public void stop(BundleContext context) throws Exception {
+		context = null;
 	}
-		
+
 }

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/test/AuthServiceImplTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/test/AuthServiceImplTest.java
@@ -26,7 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 import org.compiere.util.Env;
-import org.idempiere.test.AbstractTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -39,12 +38,13 @@ import org.mockito.MockitoAnnotations;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.trekglobal.idempiere.rest.api.json.test.RestTestCase;
 import com.trekglobal.idempiere.rest.api.v1.auth.LoginCredential;
 import com.trekglobal.idempiere.rest.api.v1.auth.filter.RequestFilter;
 import com.trekglobal.idempiere.rest.api.v1.auth.impl.AuthServiceImpl;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class AuthServiceImplTest extends AbstractTestCase {
+public class AuthServiceImplTest extends RestTestCase {
 
 	@Mock
 	private HttpServletRequest request;

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/test/AuthenticationTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/auth/impl/test/AuthenticationTest.java
@@ -25,24 +25,23 @@ import javax.ws.rs.core.Response;
 
 import org.compiere.model.MRoleOrgAccess;
 import org.compiere.util.Env;
-import org.idempiere.test.AbstractTestCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.trekglobal.idempiere.rest.api.json.test.RestTestCase;
 import com.trekglobal.idempiere.rest.api.v1.auth.LoginCredential;
 import com.trekglobal.idempiere.rest.api.v1.auth.impl.AuthServiceImpl;
 
-public class AuthenticationTest extends AbstractTestCase {
+public class AuthenticationTest extends RestTestCase {
 
 	@Mock
 	private HttpServletRequest request;
 	@InjectMocks
 	private AuthServiceImpl authService;
-
-
+	
 	@BeforeEach
 	public void setUp() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 		MockitoAnnotations.openMocks(this);


### PR DESCRIPTION
Changes to make idempiere-rest `mvn verify -DskipTests=false` works with a vanilla iDempiere database.