### PR TITLE
Add Validation for Running Processes Into Rest #370

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
@@ -203,6 +203,12 @@ public class ProcessResourceImpl implements ProcessResource {
 		MPInstance pInstance = Process.createPInstance(process, jsonObject, false);
 		
 		ProcessInfo processInfo = Process.createProcessInfo(process, pInstance, jsonObject);
+
+		if(processInfo.isProcessRunning(pInstance.getParameters())) {
+			return Response.status(Status.CONFLICT)
+					.entity(new ErrorBuilder().status(Status.CONFLICT).title("Process is Already Running. ").append(processSlug).build().toString())
+					.build();
+		}
 		
 		ServerProcessCtl.process(processInfo, null);
 		
@@ -273,6 +279,12 @@ public class ProcessResourceImpl implements ProcessResource {
 		JsonObject jsonObject = gson.fromJson(jsonText, JsonObject.class);
 		MPInstance pInstance = Process.createPInstance(process, jsonObject, true);
 		ProcessInfo processInfo = Process.createProcessInfo(process, pInstance, jsonObject);
+
+		if(processInfo.isProcessRunning(pInstance.getParameters())) {
+			return Response.status(Status.CONFLICT)
+					.entity(new ErrorBuilder().status(Status.CONFLICT).title("Process is Already Running. ").append(processSlug).build().toString())
+					.build();
+		}
 		
 		int AD_User_ID = Env.getAD_User_ID(Env.getCtx());
 		MPInstance.publishChangedEvent(AD_User_ID);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
@@ -206,7 +206,7 @@ public class ProcessResourceImpl implements ProcessResource {
 
 		if(processInfo.isProcessRunning(pInstance.getParameters())) {
 			return Response.status(Status.CONFLICT)
-					.entity(new ErrorBuilder().status(Status.CONFLICT).title("Process is Already Running. ").append(processSlug).build().toString())
+					.entity(new ErrorBuilder().status(Status.CONFLICT).title(Msg.getMsg(Env.getCtx(), "ProcessAlreadyRunning")).append(processSlug).build().toString())
 					.build();
 		}
 		
@@ -282,7 +282,7 @@ public class ProcessResourceImpl implements ProcessResource {
 
 		if(processInfo.isProcessRunning(pInstance.getParameters())) {
 			return Response.status(Status.CONFLICT)
-					.entity(new ErrorBuilder().status(Status.CONFLICT).title("Process is Already Running. ").append(processSlug).build().toString())
+					.entity(new ErrorBuilder().status(Status.CONFLICT).title(Msg.getMsg(Env.getCtx(), "ProcessAlreadyRunning")).append(processSlug).build().toString())
 					.build();
 		}
 		


### PR DESCRIPTION
Issue: https://github.com/bxservice/idempiere-rest/issues/370

Not Tested in Community environment.

- Added IsProcessRunning Check into Rest RunProcess and RunJob Endpoints to disallow duplicate running processes.
- Return 409 - Process is Already Running.

Test Case:

1. Could be checked against process RecreateStorageReservation it has set **Allow Concurrent Execution**: **Not from same user**
2. Login into Idempiere Application Dictionary as GarderUser
3. Open Recreate Storage Reservation Window
4. Login through Rest as GardenUser
5. Prepare RunProcess REST Request for RecreateStorageReservation as in Opened Window (Parameters doesnt matter.)
6. Run Recreate Storage Reservation in Window
7. Run Rest Process Endpoint
8. Rest Endpoint should return 409.