### PR TITLE
Save error when creating Business Partner, Partner Location and Location in one request using reference rest view #395

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
@@ -191,7 +191,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 
 			MTable table = MTable.get(Env.getCtx(), MLocation.Table_ID);
 			POInfo poInfo = POInfo.getPOInfo(Env.getCtx(), table.getAD_Table_ID());
-			DefaultPOSerializer.validateJsonFields(json, po);
+			DefaultPOSerializer.validateJsonFields(json, po, referenceView);
 			Set<String> jsonFields = json.keySet();
 			MRestViewColumn[] viewColumns = referenceView != null ? referenceView.getColumns() : null;
 			int count = viewColumns != null ? viewColumns.length : poInfo.getColumnCount(); 


### PR DESCRIPTION
[Save error when creating Business Partner, Partner Location and Location in one request using reference rest view #395](https://github.com/bxservice/idempiere-rest/issues/395)

Minor bug fix. Pass the referenceView when calling DefaultPOSerializer.validateJsonFields.
