### PR TITLE
Implement health check endpoint #116

### DIFF
--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -6664,6 +6664,12 @@ paths:
           schema:
             type: string
           description: optional health monitoring key, required if configure at backend
+        - name: db
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: optional flag to enable/disable database connection check. default is false
       responses:
         '200':
           description: UP response

--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -54,6 +54,8 @@ tags:
     description: Endpoints to upload files
   - name: Batch
     description: Endpoints for batch processing
+  - name: Health
+    description: Endpoints for health monitoring
 components:
   securitySchemes:
     bearerAuth: # arbitrary name for the security scheme
@@ -6650,3 +6652,46 @@ paths:
                 $ref: '#/components/schemas/BatchResponse'
         '500':
           $ref: '#/components/responses/ServerError'
+  /health:
+    get:
+      tags:
+        - Health
+      summary: Health monitoring
+      parameters:
+        - name: key
+          in: query
+          required: false
+          schema:
+            type: string
+          description: optional health monitoring key, required if configure at backend
+      responses:
+        '200':
+          description: UP response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: 
+                      - UP
+                  database:
+                    type: string
+                    enum: 
+                      - connected
+        '503':
+          description: DOWN response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: 
+                      - DOWN
+                  database:
+                    type: string
+                    enum: 
+                      - disconnected

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -5496,7 +5496,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/health?key={{healthMonitoringKey}}",
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/health?key={{healthMonitoringKey}}&db={{dbStatusCheck}}",
 					"protocol": "{{protocol}}",
 					"host": [
 						"{{host}}"
@@ -5511,6 +5511,10 @@
 						{
 							"key": "key",
 							"value": "{{healthMonitoringKey}}"
+						},
+						{
+							"key": "db",
+							"value": "{{dbStatusCheck}}"
 						}
 					]
 				}

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -5489,6 +5489,33 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "api/v1/health",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/health?key={{healthMonitoringKey}}",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"health"
+					],
+					"query": [
+						{
+							"key": "key",
+							"value": "{{healthMonitoringKey}}"
+						}
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"event": [

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/ApplicationV1.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/ApplicationV1.java
@@ -45,6 +45,7 @@ import com.trekglobal.idempiere.rest.api.v1.resource.impl.CacheResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.ChartResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.FileResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.FormResourceImpl;
+import com.trekglobal.idempiere.rest.api.v1.resource.impl.HealthResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.InfoResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.MenuTreeResourceImpl;
 import com.trekglobal.idempiere.rest.api.v1.resource.impl.ModelResourceImpl;
@@ -98,6 +99,7 @@ public class ApplicationV1 extends Application {
         classes.add(TaskResourceImpl.class);
         classes.add(UploadResourceImpl.class);
         classes.add(BatchRequestResourseImpl.class);
+        classes.add(HealthResourceImpl.class);
         
         IServicesHolder<ResourceExtension> list = Service.locator().list(ResourceExtension.class);
         for (IServiceReferenceHolder<ResourceExtension> holder : list.getServiceReferences()) {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
@@ -1,0 +1,40 @@
+/**********************************************************************
+* This file is part of iDempiere ERP Open Source                      *
+* http://www.idempiere.org                                            *
+*                                                                     *
+* Copyright (C) Contributors                                          *
+*                                                                     *
+* This program is free software; you can redistribute it and/or       *
+* modify it under the terms of the GNU General Public License         *
+* as published by the Free Software Foundation; either version 2      *
+* of the License, or (at your option) any later version.              *
+*                                                                     *
+* This program is distributed in the hope that it will be useful,     *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+* GNU General Public License for more details.                        *
+*                                                                     *
+* You should have received a copy of the GNU General Public License   *
+* along with this program; if not, write to the Free Software         *
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+* MA 02110-1301, USA.                                                 *
+*                                                                     *
+* Contributors:                                                       *
+* - Trek Global Corporation                                           *
+* - Heng Sin Low                                                      *
+**********************************************************************/
+package com.trekglobal.idempiere.rest.api.v1.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/v1/health")
+public interface HealthResource {
+
+	@GET
+    @Produces(MediaType.APPLICATION_JSON)
+	Response getHealthStatus();
+}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/HealthResource.java
@@ -28,6 +28,7 @@ package com.trekglobal.idempiere.rest.api.v1.resource;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,5 +37,5 @@ public interface HealthResource {
 
 	@GET
     @Produces(MediaType.APPLICATION_JSON)
-	Response getHealthStatus();
+	Response getHealthStatus(@QueryParam("db") boolean dbstatus);
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
@@ -1,0 +1,111 @@
+/**********************************************************************
+* This file is part of iDempiere ERP Open Source                      *
+* http://www.idempiere.org                                            *
+*                                                                     *
+* Copyright (C) Contributors                                          *
+*                                                                     *
+* This program is free software; you can redistribute it and/or       *
+* modify it under the terms of the GNU General Public License         *
+* as published by the Free Software Foundation; either version 2      *
+* of the License, or (at your option) any later version.              *
+*                                                                     *
+* This program is distributed in the hope that it will be useful,     *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+* GNU General Public License for more details.                        *
+*                                                                     *
+* You should have received a copy of the GNU General Public License   *
+* along with this program; if not, write to the Free Software         *
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+* MA 02110-1301, USA.                                                 *
+*                                                                     *
+* Contributors:                                                       *
+* - Trek Global Corporation                                           *
+* - Heng Sin Low                                                      *
+**********************************************************************/
+package com.trekglobal.idempiere.rest.api.v1.resource.impl;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+
+import javax.ws.rs.core.Response;
+
+import org.compiere.Adempiere;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+
+import com.google.gson.JsonObject;
+import com.trekglobal.idempiere.rest.api.v1.resource.HealthResource;
+
+public class HealthResourceImpl implements HealthResource {
+
+	private static final CLogger log = CLogger.getCLogger(HealthResourceImpl.class);
+	
+    // cached health status
+    private static class HealthStatus {
+        final int httpStatusCode;
+        final String jsonResponse;
+
+        HealthStatus(int httpStatusCode, String jsonResponse) {
+            this.httpStatusCode = httpStatusCode;
+            this.jsonResponse = jsonResponse;
+        }
+    }
+
+    // Cache duration in milliseconds
+    private static final long CACHE_DURATION_MS = 60000; //60 seconds
+
+    private static final AtomicLong lastCheckTimestamp = new AtomicLong(0);
+    private static final AtomicReference<HealthStatus> cachedStatus = new AtomicReference<>();
+
+    @Override
+    public Response getHealthStatus() {
+        long now = System.currentTimeMillis();
+        long lastCheck = lastCheckTimestamp.get();
+
+        // Check if the cached result is still valid
+        if (now - lastCheck < CACHE_DURATION_MS && cachedStatus.get() != null) {
+            HealthStatus status = cachedStatus.get();
+            if (log.isLoggable(Level.FINE))
+            	log.fine("Returning cached health status: " + status.jsonResponse);
+            return Response.status(status.httpStatusCode).entity(status.jsonResponse).build();
+        }
+
+        // The cache is stale. We need to try and update it.
+        if (lastCheckTimestamp.compareAndSet(lastCheck, now)) {
+            try {
+            	// use thread to enforce 2 second timeout
+            	Future<Boolean> future = Adempiere.getThreadPoolExecutor().submit(() -> {
+            		return DB.isConnected(); //depends on HikariCP connection timeout settings, this can be longer than 2 minutes
+            	});            	
+            	boolean isConnected = false;
+            	try {
+            		isConnected = future.get(2, TimeUnit.SECONDS);
+            	} catch (Exception e) {}
+            	
+                if (isConnected) {
+                    updateCache(200, "UP", "connected");
+                } else {
+                    updateCache(503, "DOWN", "disconnected");
+                }
+            } catch (Exception e) {
+                updateCache(503, "DOWN", "disconnected");
+            }
+        }
+        
+        HealthStatus status = cachedStatus.get();
+        return Response.status(status.httpStatusCode).entity(status.jsonResponse).build();
+    }
+    
+    private void updateCache(int code, String status, String dbStatus) {
+    	if (log.isLoggable(Level.FINE))
+    		log.fine("Updating health status cache: " + status + ", database: " + dbStatus);
+        JsonObject responseJson = new JsonObject();
+        responseJson.addProperty("status", status);
+        responseJson.addProperty("database", dbStatus);
+        cachedStatus.set(new HealthStatus(code, responseJson.toString()));
+    }
+}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/HealthResourceImpl.java
@@ -31,16 +31,30 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 import org.compiere.Adempiere;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
+import org.compiere.util.Util;
 
 import com.google.gson.JsonObject;
 import com.trekglobal.idempiere.rest.api.v1.resource.HealthResource;
 
 public class HealthResourceImpl implements HealthResource {
+
+	// System or environment property to override REST health check cache duration in milliseconds
+	private static final String REST_HEALTH_CACHE_DURATION_PROPERTY = "REST_HEALTH_CACHE_DURATION";
+
+	private static final String DISCONNECTED_STATUS_TEXT = "disconnected";
+
+	private static final String CONNECTED_STATUS_TEXT = "connected";
+
+	private static final String DOWN_STATUS_TEXT = "DOWN";
+
+	private static final String UP_STATUS_TEXT = "UP";
 
 	private static final CLogger log = CLogger.getCLogger(HealthResourceImpl.class);
 	
@@ -56,56 +70,103 @@ public class HealthResourceImpl implements HealthResource {
     }
 
     // Cache duration in milliseconds
-    private static final long CACHE_DURATION_MS = 60000; //60 seconds
+    private static long CACHE_DURATION_MS = 20000; //20 seconds
+    static {
+    	String duration = System.getProperty(REST_HEALTH_CACHE_DURATION_PROPERTY);
+		if (Util.isEmpty(duration, true))
+			duration = System.getenv(REST_HEALTH_CACHE_DURATION_PROPERTY);
+		
+		if (!Util.isEmpty(duration, true)) {
+			try {
+				long d = Long.parseLong(duration);
+				if (d >= 0) {
+					// set cache duration
+					CACHE_DURATION_MS = d;
+				} else {
+					log.warning("Ignoring invalid negative REST_HEALTH_CACHE_DURATION=" + duration);
+				}
+			} catch (NumberFormatException e) {
+				log.warning("Ignoring invalid non-numeric REST_HEALTH_CACHE_DURATION=" + duration);
+			}
+		}
+    }
 
+    private static final AtomicLong dbLastCheckTimestamp = new AtomicLong(0);
     private static final AtomicLong lastCheckTimestamp = new AtomicLong(0);
+    private static final AtomicReference<HealthStatus> dbCachedStatus = new AtomicReference<>();
     private static final AtomicReference<HealthStatus> cachedStatus = new AtomicReference<>();
 
+    @Context
+	private ResourceContext resourceContext;
+    
     @Override
-    public Response getHealthStatus() {
+    public Response getHealthStatus(boolean dbstatus) {
+    	AtomicLong timeStamp = dbstatus ? dbLastCheckTimestamp : lastCheckTimestamp;
+    	AtomicReference<HealthStatus> statusRef = dbstatus ? dbCachedStatus : cachedStatus;
+    	
         long now = System.currentTimeMillis();
-        long lastCheck = lastCheckTimestamp.get();
+        long lastCheck = timeStamp.get();
 
         // Check if the cached result is still valid
-        if (now - lastCheck < CACHE_DURATION_MS && cachedStatus.get() != null) {
-            HealthStatus status = cachedStatus.get();
+        if (now - lastCheck < CACHE_DURATION_MS && statusRef.get() != null) {
+            HealthStatus status = statusRef.get();
             if (log.isLoggable(Level.FINE))
             	log.fine("Returning cached health status: " + status.jsonResponse);
             return Response.status(status.httpStatusCode).entity(status.jsonResponse).build();
         }
 
         // The cache is stale. We need to try and update it.
-        if (lastCheckTimestamp.compareAndSet(lastCheck, now)) {
-            try {
-            	// use thread to enforce 2 second timeout
-            	Future<Boolean> future = Adempiere.getThreadPoolExecutor().submit(() -> {
-            		return DB.isConnected(); //depends on HikariCP connection timeout settings, this can be longer than 2 minutes
-            	});            	
-            	boolean isConnected = false;
-            	try {
-            		isConnected = future.get(2, TimeUnit.SECONDS);
-            	} catch (Exception e) {}
-            	
-                if (isConnected) {
-                    updateCache(200, "UP", "connected");
-                } else {
-                    updateCache(503, "DOWN", "disconnected");
-                }
-            } catch (Exception e) {
-                updateCache(503, "DOWN", "disconnected");
-            }
+        if (timeStamp.compareAndSet(lastCheck, now)) {
+        	ModelResourceImpl modelResource = resourceContext.getResource(ModelResourceImpl.class);
+        	if (dbstatus) {
+	            try {
+	            	// use thread to enforce 2 second timeout
+	            	Future<Boolean> future = Adempiere.getThreadPoolExecutor().submit(() -> {
+	            		return DB.isConnected(); //depends on HikariCP connection timeout settings, this can be longer than 2 minutes
+	            	});            	
+	            	boolean isConnected = false;
+	            	try {
+	            		isConnected = future.get(2, TimeUnit.SECONDS);
+	            	} catch (Exception e) {}
+	            	
+	                if (isConnected) {
+	                	if (modelResource != null)
+	                		updateCache(Response.Status.OK.getStatusCode(), UP_STATUS_TEXT, CONNECTED_STATUS_TEXT);
+	                	else
+	                		updateCache(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), DOWN_STATUS_TEXT, CONNECTED_STATUS_TEXT);
+	                } else {
+	                    updateCache(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), DOWN_STATUS_TEXT, DISCONNECTED_STATUS_TEXT);
+	                }
+	            } catch (Exception e) {
+	                updateCache(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), DOWN_STATUS_TEXT, DISCONNECTED_STATUS_TEXT);
+	            }
+        	} else {
+    			if (modelResource != null) {
+    				updateCache(Response.Status.OK.getStatusCode(), UP_STATUS_TEXT, null);
+    			} else {
+    				updateCache(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), DOWN_STATUS_TEXT, null);
+    			}
+        	}
         }
         
-        HealthStatus status = cachedStatus.get();
+        HealthStatus status = statusRef.get();
         return Response.status(status.httpStatusCode).entity(status.jsonResponse).build();
     }
     
     private void updateCache(int code, String status, String dbStatus) {
-    	if (log.isLoggable(Level.FINE))
-    		log.fine("Updating health status cache: " + status + ", database: " + dbStatus);
+    	if (log.isLoggable(Level.FINE)) {
+    		if (dbStatus != null)
+    			log.fine("Updating health status cache: " + status + ", database: " + dbStatus);
+    		else
+    			log.fine("Updating health status cache: " + status);
+    	}
         JsonObject responseJson = new JsonObject();
         responseJson.addProperty("status", status);
-        responseJson.addProperty("database", dbStatus);
-        cachedStatus.set(new HealthStatus(code, responseJson.toString()));
+        if (dbStatus != null) {
+        	responseJson.addProperty("database", dbStatus);
+        	dbCachedStatus.set(new HealthStatus(code, responseJson.toString()));
+        } else {
+        	cachedStatus.set(new HealthStatus(code, responseJson.toString()));
+        }
     }
 }


### PR DESCRIPTION
Implemented basic protection for DDOS:
- Health status is cache for 60 seconds
- DB check is enforce a max timeout of 2 seconds
- Optional AD_SysConfig.Name=REST_HEALTH_MONITORING_KEY key

More robust  and efficient DDOS protection should be implemented using API Gateway or Reverse Proxy (Nginx) configuration.