### PR TITLE
Insert of new record for UUID table is not working correctly #415

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -187,7 +187,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 	
 	@Override
 	public PO fromJson(JsonObject json, MTable table, MRestView view) {
-		PO po = table.getPO(0, null);
+		PO po = table.isUUIDKeyTable() ? table.getPOByUU(PO.UUID_NEW_RECORD, null) : table.getPO(0, null);
 		POInfo poInfo = POInfo.getPOInfo(Env.getCtx(), table.getAD_Table_ID());
 		validateJsonFields(json, po, view);
 		Set<String> jsonFields = json.keySet();


### PR DESCRIPTION
[Insert of new record for UUID table is not working correctly #415](https://github.com/bxservice/idempiere-rest/issues/415)

Insert of new record for UUID table is not working correctly. This is related to [IDEMPIERE-6700](https://idempiere.atlassian.net/browse/IDEMPIERE-6700) GridTable.dataSavePO is not working correctly for UUID table.