### PR TITLE
Error when creating a creating a UU-based parent record with UU-based child records (Foreign ID 0 not found in ParentTable_UU) #427

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -528,7 +528,13 @@ public class ModelResourceImpl implements ModelResource {
 								throw new AdempiereException("AccessCannotUpdate");
 							
 							childPO.set_TrxName(trx.getTrxName());
-							childPO.set_ValueOfColumn(RestUtils.getKeyColumnName(po.get_TableName()), po.get_ID());
+							
+							MTable table = MTable.get(Env.getCtx(), po.get_TableName());
+							if (table.isUUIDKeyTable())
+								childPO.set_ValueOfColumn(RestUtils.getKeyColumnName(po.get_TableName()), po.get_UUID());
+							else
+								childPO.set_ValueOfColumn(RestUtils.getKeyColumnName(po.get_TableName()), po.get_ID());
+							
 							fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, true);
 							childPO.validForeignKeysEx();
 							childPO.saveEx();


### PR DESCRIPTION
[Error when creating a UU-based parent record with UU-based child records (Foreign ID 0 not found in ParentTable_UU) #427](https://github.com/bxservice/idempiere-rest/issues/427)

Check if the PO is a UUID-based table, use get_UUID for UUID-based table.