### PR TITLE
Fixes #461 Expand to master table is failing if $select doesn't include the expanded column

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/expand/ExpandParser.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/expand/ExpandParser.java
@@ -160,13 +160,12 @@ public class ExpandParser {
 		if ("Node_ID".equalsIgnoreCase(columnName) && po.get_ValueAsInt("AD_Tree_ID") > 0) {
 			tableName = MTree_Base.get(po.get_ValueAsInt("AD_Tree_ID")).getSourceTableName(true);
 		}
-		String foreignTableID = po.get_ValueAsString(columnName);
-		if (Util.isEmpty(foreignTableID) && po.isPartial() && !po.isColumnLoaded(columnName)) {
+		if (po.is_Partial() && !po.is_ColumnLoaded(columnName)) {
 			// the foreign key was not included, reload the PO
 			log.warning("For performance reasons, it is recommended to include foreign keys in the $select clause when expanding master records. Reloaded PO to get value for column: " + columnName);
 			po.load(po.get_TrxName());
-			foreignTableID = po.get_ValueAsString(columnName);
 		}
+		String foreignTableID = po.get_ValueAsString(columnName);
 		
 		Query query = RestUtils.getQuery(tableName, foreignTableID, true, false);
 


### PR DESCRIPTION
Requires https://github.com/idempiere/idempiere/pull/3073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of related-record expansion when initial data is partial or incomplete.
  * Automatically reloads missing foreign-key values to ensure expansions succeed.
  * Added warnings to improve diagnostic visibility for expansion operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->