### PR TITLE
Implement Dry Run option for Windows end points #481

### DIFF
--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4406,6 +4406,10 @@ paths:
                     "doc-action": "CO"
                   }
       responses:
+        '200':
+          description: Dry run successful 
+          content:
+            application/json: {}
         '201':
           description: Successful response
           content:
@@ -4416,30 +4420,30 @@ paths:
           $ref: '#/components/responses/ServerError'
   /windows/{windowSlug}/{id}:
     parameters:
+      - name: windowSlug
+        in: path
+        required: true
+        description: slugify window name
+        schema:
+          type: string
+        examples:
+          bankCashWindow:
+            value: 'bank-cash'
+      - name: id
+        in: path
+        required: true
+        description: record id
+        schema:
+          type: integer
+        examples:
+          bankCash_100:
+            value: 100
       - $ref: '#/components/parameters/locale'
     get:
       tags:
         - Windows
       summary: Get record by id
-      parameters:
-        - name: windowSlug
-          in: path
-          required: true
-          description: slugify window name
-          schema:
-            type: string
-          examples:
-            bankCashWindow:
-              value: 'bank-cash'
-        - name: id
-          in: path
-          required: true
-          description: record id
-          schema:
-            type: integer
-          examples:
-            bankCash_100:
-              value: 100
+      parameters:        
         - name: $expand
           in: query
           schema:
@@ -4459,6 +4463,37 @@ paths:
           $ref: '#/components/responses/ServerError'
         '404':
           $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+        - Windows
+      summary: Update window record by id (tab 0)
+      parameters:
+        - name: $save
+          in: query
+          description: optional flag to save changes to database
+          schema:
+            type: boolean
+            default: true
+          required: false
+      requestBody:
+        content:
+          application/json:
+            examples:
+              bankCashWindow:
+                value:
+                  {
+                      "Name": "My MoneyBank"
+                  }
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+        '500':
+          $ref: '#/components/responses/ServerError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /windows/{windowSlug}/{id}/print:
     parameters:
       - $ref: '#/components/parameters/locale'
@@ -4690,6 +4725,10 @@ paths:
                       }
                   }
       responses:
+        '200':
+          description: Dry run successful 
+          content:
+            application/json: {}
         '201':
           description: Successful response
           content:

--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4383,7 +4383,7 @@ paths:
       parameters:
         - name: $save
           in: query
-          description: optional flag to save changes to database
+          description: If false, applies default values and callouts without persisting changes to the database
           schema:
             type: boolean
             default: true
@@ -4470,7 +4470,7 @@ paths:
       parameters:
         - name: $save
           in: query
-          description: optional flag to save changes to database
+          description: If false, applies default values and callouts without persisting changes to the database
           schema:
             type: boolean
             default: true
@@ -4581,7 +4581,7 @@ paths:
       parameters:
         - name: $save
           in: query
-          description: optional flag to save changes to database
+          description: If false, applies default values and callouts without persisting changes to the database
           schema:
             type: boolean
             default: true
@@ -4699,7 +4699,7 @@ paths:
       parameters:
         - name: $save
           in: query
-          description: optional flag to save changes to database
+          description: If false, applies default values and callouts without persisting changes to the database
           schema:
             type: boolean
             default: true

--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4320,14 +4320,14 @@ paths:
       parameters:        
         - name: $filter
           in: query
-          description: SQL filter clause
+          description: oData filter clause
           schema:
             type: string
           examples:
             noFilter:
               value: ''
             BankCash_Name:
-              value: Name='MoneyBank'
+              value: Name eq 'MoneyBank'
         - name: $sort_column
           in: query
           description: Column to sort by, use ! prefix for descending sort
@@ -4380,6 +4380,14 @@ paths:
       tags:
         - Windows
       summary: Create window record
+      parameters:
+        - name: $save
+          in: query
+          description: optional flag to save changes to database
+          schema:
+            type: boolean
+            default: true
+          required: false
       requestBody:
         content:
           application/json:
@@ -4535,6 +4543,14 @@ paths:
       tags:
         - Windows
       summary: Update tab record by id
+      parameters:
+        - name: $save
+          in: query
+          description: optional flag to save changes to database
+          schema:
+            type: boolean
+            default: true
+          required: false
       requestBody:
         content:
           application/json:
@@ -4645,6 +4661,14 @@ paths:
       tags:
         - Windows
       summary: create child tab record
+      parameters:
+        - name: $save
+          in: query
+          description: optional flag to save changes to database
+          schema:
+            type: boolean
+            default: true
+          required: false
       requestBody:
         content:
           application/json:

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -2153,6 +2153,55 @@
 			"response": []
 		},
 		{
+			"name": "api/v1/windows/sales-order dry run",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"isSOTrx\": true,\n\t\"C_DocTypeTarget_ID\": { \"identifier\": \"Standard Order\" },\n\t\"C_BPartner_ID\" : { \"identifier\": \"C&W Construction\" }\n}"
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/windows/sales-order",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"windows",
+						"sales-order"
+					],
+					"query": [
+						{
+							"key": "$save",
+							"value": "false"
+						}
+					]
+				},
+				"description": "Example to post sales order without saving to DB."
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/forms",
 			"request": {
 				"method": "GET",

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/WindowResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/WindowResource.java
@@ -34,6 +34,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -145,9 +146,10 @@ public interface WindowResource {
 	 * @param windowSlug slug of window name
 	 * @param recordId
 	 * @param jsonText json representation of data to process
+	 * @param save optional flag to save record, default true
 	 * @return json representation of updated record
 	 */
-	public Response updateWindowRecord(@PathParam("windowSlug") String windowSlug, @PathParam("recordId") int recordId, String jsonText);
+	public Response updateWindowRecord(@PathParam("windowSlug") String windowSlug, @PathParam("recordId") int recordId, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
 	
 	@Path("{windowSlug}")
 	@POST
@@ -159,9 +161,10 @@ public interface WindowResource {
 	 *   doc-action (document action to execute)
 	 * @param windowSlug slug of window name
 	 * @param jsonText json representation of data to process
+	 * @param save optional flag to save record, default true
 	 * @return json representation of created record
 	 */
-	public Response createWindowRecord(@PathParam("windowSlug") String windowSlug, String jsonText);
+	public Response createWindowRecord(@PathParam("windowSlug") String windowSlug, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
 	
 	@Path("{windowSlug}/{recordId}")
 	@DELETE
@@ -186,9 +189,10 @@ public interface WindowResource {
 	 * @param tabSlug slug of tab name
 	 * @param recordId
 	 * @param jsonText json representation of data to process
+	 * @param save optional flag to save record, default true
 	 * @return json representation of updated record
 	 */
-	public Response updateTabRecord(@PathParam("windowSlug") String windowSlug, @PathParam("tabSlug") String tabSlug, @PathParam("recordId") int recordId, String jsonText);
+	public Response updateTabRecord(@PathParam("windowSlug") String windowSlug, @PathParam("tabSlug") String tabSlug, @PathParam("recordId") int recordId, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
 	
 	@Path("{windowSlug}/tabs/{tabSlug}/{recordId}/{childTabSlug}")
 	@POST
@@ -201,10 +205,11 @@ public interface WindowResource {
 	 * @param recordId id of parent record
 	 * @param childTabSlug slug of child tab name
 	 * @param jsonText json representation of created record
+	 * @param save optional flag to save record, default true
 	 * @return json representation of created record
 	 */
 	public Response createChildTabRecord(@PathParam("windowSlug") String windowSlug, @PathParam("tabSlug") String tabSlug, @PathParam("recordId") int recordId, 
-			@PathParam("childTabSlug") String childTabSlug, String jsonText);
+			@PathParam("childTabSlug") String childTabSlug, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
 	
 	@Path("{windowSlug}/tabs/{tabSlug}/{recordId}")
 	@DELETE

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/WindowResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/WindowResource.java
@@ -146,7 +146,7 @@ public interface WindowResource {
 	 * @param windowSlug slug of window name
 	 * @param recordId
 	 * @param jsonText json representation of data to process
-	 * @param save optional flag to save record, default true
+	 * @param save If false, applies default values and callouts without persisting changes to the database
 	 * @return json representation of updated record
 	 */
 	public Response updateWindowRecord(@PathParam("windowSlug") String windowSlug, @PathParam("recordId") int recordId, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
@@ -161,7 +161,7 @@ public interface WindowResource {
 	 *   doc-action (document action to execute)
 	 * @param windowSlug slug of window name
 	 * @param jsonText json representation of data to process
-	 * @param save optional flag to save record, default true
+	 * @param save If false, applies default values and callouts without persisting changes to the database
 	 * @return json representation of created record
 	 */
 	public Response createWindowRecord(@PathParam("windowSlug") String windowSlug, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
@@ -189,7 +189,7 @@ public interface WindowResource {
 	 * @param tabSlug slug of tab name
 	 * @param recordId
 	 * @param jsonText json representation of data to process
-	 * @param save optional flag to save record, default true
+	 * @param save If false, applies default values and callouts without persisting changes to the database
 	 * @return json representation of updated record
 	 */
 	public Response updateTabRecord(@PathParam("windowSlug") String windowSlug, @PathParam("tabSlug") String tabSlug, @PathParam("recordId") int recordId, String jsonText, @QueryParam("$save") @DefaultValue("true") boolean save);
@@ -205,7 +205,7 @@ public interface WindowResource {
 	 * @param recordId id of parent record
 	 * @param childTabSlug slug of child tab name
 	 * @param jsonText json representation of created record
-	 * @param save optional flag to save record, default true
+	 * @param save If false, applies default values and callouts without persisting changes to the database
 	 * @return json representation of created record
 	 */
 	public Response createChildTabRecord(@PathParam("windowSlug") String windowSlug, @PathParam("tabSlug") String tabSlug, @PathParam("recordId") int recordId, 

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WindowResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WindowResourceImpl.java
@@ -503,12 +503,12 @@ public class WindowResourceImpl implements WindowResource {
 	}
 	
 	@Override
-	public Response updateWindowRecord(String windowSlug, int recordId, String jsonText) {
-		return updateTabRecord(windowSlug, null, recordId, jsonText);
+	public Response updateWindowRecord(String windowSlug, int recordId, String jsonText, boolean save) {
+		return updateTabRecord(windowSlug, null, recordId, jsonText, save);
 	}
 
 	@Override
-	public Response createWindowRecord(String windowSlug, String jsonText) {
+	public Response createWindowRecord(String windowSlug, String jsonText, boolean save) {
 		MRole role = MRole.getDefault();
 		Query query = new Query(Env.getCtx(), MWindow.Table_Name, "slugify(name)=?", null);
 		query.setApplyAccessFilter(true).setOnlyActiveRecords(true);
@@ -545,7 +545,7 @@ public class WindowResourceImpl implements WindowResource {
 		try {
 			if (threadLocalTrxName == null)
 				trx.start();
-			return createTabRecord(gridWindow, null, null, jsonObject, trx, (threadLocalTrxName != null));
+			return createTabRecord(gridWindow, null, null, jsonObject, trx, (threadLocalTrxName != null), save);
 		} catch (Exception ex) {
 			trx.rollback();
 			log.log(Level.SEVERE, ex.getMessage(), ex);
@@ -564,7 +564,7 @@ public class WindowResourceImpl implements WindowResource {
 	}
 
 	@Override
-	public Response updateTabRecord(String windowSlug, String tabSlug, int recordId, String jsonText) {
+	public Response updateTabRecord(String windowSlug, String tabSlug, int recordId, String jsonText, boolean save) {
 		MRole role = MRole.getDefault();
 		Query query = new Query(Env.getCtx(), MWindow.Table_Name, "slugify(name)=?", null);
 		query.setApplyAccessFilter(true).setOnlyActiveRecords(true);
@@ -600,7 +600,7 @@ public class WindowResourceImpl implements WindowResource {
 		try {
 			if (threadLocalTrxName == null)
 				trx.start();
-			return updateTabRecord(gridWindow, tabSlug, recordId, jsonObject, trx, (threadLocalTrxName != null));
+			return updateTabRecord(gridWindow, tabSlug, recordId, jsonObject, trx, (threadLocalTrxName != null), save);
 		} catch (Exception ex) {
 			trx.rollback();
 			log.log(Level.SEVERE, ex.getMessage(), ex);
@@ -615,7 +615,7 @@ public class WindowResourceImpl implements WindowResource {
 
 	@Override
 	public Response createChildTabRecord(String windowSlug, String tabSlug, int recordId, String childTabSlug,
-			String jsonText) {
+			String jsonText, boolean save) {
 		MRole role = MRole.getDefault();
 		Query query = new Query(Env.getCtx(), MWindow.Table_Name, "slugify(name)=?", null);
 		query.setApplyAccessFilter(true).setOnlyActiveRecords(true);
@@ -673,7 +673,7 @@ public class WindowResourceImpl implements WindowResource {
 		try {
 			if (threadLocalTrxName == null)
 				trx.start();
-			return createTabRecord(gridWindow, parentTab, childTabSlug, jsonObject, trx, (threadLocalTrxName != null));
+			return createTabRecord(gridWindow, parentTab, childTabSlug, jsonObject, trx, (threadLocalTrxName != null), save);
 		} catch (Exception ex) {
 			trx.rollback();
 			log.log(Level.SEVERE, ex.getMessage(), ex);
@@ -941,7 +941,7 @@ public class WindowResourceImpl implements WindowResource {
 		return serializer;
 	}
 	
-	private Response updateTabRecord(GridWindow gridWindow, String tabSlug, int recordId, JsonObject jsonObject, Trx trx, boolean threadLocalTrx)
+	private Response updateTabRecord(GridWindow gridWindow, String tabSlug, int recordId, JsonObject jsonObject, Trx trx, boolean threadLocalTrx, boolean save)
 			throws SQLException {
 		Response errorResponse = null;
 		GridTab headerTab = null;
@@ -971,7 +971,7 @@ public class WindowResourceImpl implements WindowResource {
 					break;
 				}				
 				serializer.fromJson(jsonObject, gridTab);
-				if (gridTab.needSave(true, true)) {
+				if (save && gridTab.needSave(true, true)) {
 					ErrorDataStatusListener edsl = new ErrorDataStatusListener();
 					gridTab.getTableModel().addDataStatusListener(edsl);
 					try {
@@ -1017,7 +1017,7 @@ public class WindowResourceImpl implements WindowResource {
 									gridTab.setValue(gridTab.getLinkColumnName(), recordId);
 								}
 								serializer.fromJson(childJsonObject, gridTab);
-								if (gridTab.needSave(true, true)) {
+								if (save && gridTab.needSave(true, true)) {
 									if (!gridTab.dataSave(false))  {
 										error[0] = Boolean.TRUE;
 										return;
@@ -1056,10 +1056,17 @@ public class WindowResourceImpl implements WindowResource {
 			return errorResponse;
 		}
 		
-		String error = runDocAction(headerTab, jsonObject, trx.getTrxName());
+		String error = null;
+		if (save) {
+			error = runDocAction(headerTab, jsonObject, trx.getTrxName());
+		}
 		if (Util.isEmpty(error, true)) {
-			if (!threadLocalTrx)
-				trx.commit(true);
+			if (!threadLocalTrx) {
+				if (save)
+					trx.commit(true);
+				else
+					trx.rollback();
+			}
 		} else {
 			trx.rollback();
 			return Response.status(Status.INTERNAL_SERVER_ERROR)
@@ -1110,7 +1117,7 @@ public class WindowResourceImpl implements WindowResource {
 		return false;
 	}
 	
-	private Response createTabRecord(GridWindow gridWindow, GridTab parentTab, String tabSlug, JsonObject jsonObject, Trx trx, boolean threadLocalTrx) throws SQLException {
+	private Response createTabRecord(GridWindow gridWindow, GridTab parentTab, String tabSlug, JsonObject jsonObject, Trx trx, boolean threadLocalTrx, boolean save) throws SQLException {
 		GridTab headerTab = null;
 		Map<String, JsonArray> childMap = new LinkedHashMap<String, JsonArray>();
 		for(int i = 0; i < gridWindow.getTabCount(); i++) {
@@ -1162,17 +1169,19 @@ public class WindowResourceImpl implements WindowResource {
 								.build();
 					}
 					serializer.fromJson(jsonObject, gridTab);
-					if (!gridTab.dataSave(false))  {
-						trx.rollback();
-						String error = edsl.getError();
-						return Response.status(Status.INTERNAL_SERVER_ERROR)
-								.entity(new ErrorBuilder().status(Status.INTERNAL_SERVER_ERROR).title("Save error")
-										.append(!Util.isEmpty(error) ? "Save error with exception: " : "")
-										.append(!Util.isEmpty(error) ? error : "")
-										.build().toString())
-								.build();
-					} else {
-						gridTab.dataRefresh(false);
+					if (save) {
+						if (!gridTab.dataSave(false))  {
+							trx.rollback();
+							String error = edsl.getError();
+							return Response.status(Status.INTERNAL_SERVER_ERROR)
+									.entity(new ErrorBuilder().status(Status.INTERNAL_SERVER_ERROR).title("Save error")
+											.append(!Util.isEmpty(error) ? "Save error with exception: " : "")
+											.append(!Util.isEmpty(error) ? error : "")
+											.build().toString())
+									.build();
+						} else {
+							gridTab.dataRefresh(false);
+						}
 					}
 				} finally {
 					gridTab.removeDataStatusListener(edsl);
@@ -1205,11 +1214,13 @@ public class WindowResourceImpl implements WindowResource {
 								}
 								gridTab.setValue(gridTab.getLinkColumnName(), finalHeaderTab.getKeyID(0));								
 								serializer.fromJson(childJsonObject, gridTab);
-								if (!gridTab.dataSave(false))  {
-									error[0] = Boolean.TRUE;
-									return;
-								} else {
-									gridTab.dataRefresh(false);
+								if (save) {
+									if (!gridTab.dataSave(false))  {
+										error[0] = Boolean.TRUE;
+										return;
+									} else {
+										gridTab.dataRefresh(false);
+									}
 								}
 								childJsonObject = serializer.toJson(gridTab);
 								updatedArray.add(childJsonObject);
@@ -1237,10 +1248,17 @@ public class WindowResourceImpl implements WindowResource {
 			}
 		}
 		
-		String error = runDocAction(headerTab, jsonObject, trx.getTrxName());
+		String error = null;
+		if (save) {
+			error = runDocAction(headerTab, jsonObject, trx.getTrxName());
+		}
 		if (Util.isEmpty(error, true)) {
-			if (!threadLocalTrx)
-				trx.commit(true);
+			if (!threadLocalTrx) {
+				if (save)
+					trx.commit(true);
+				else
+					trx.rollback();
+			}
 		} else {
 			trx.rollback();
 			return Response.status(Status.INTERNAL_SERVER_ERROR)
@@ -1258,7 +1276,7 @@ public class WindowResourceImpl implements WindowResource {
 				}
 			}
 		}
-		ResponseBuilder responseBuilder = Response.status(Status.CREATED);
+		ResponseBuilder responseBuilder = save ? Response.status(Status.CREATED) : Response.status(Status.OK);
 		if (updatedJsonObject != null)
 			return responseBuilder.entity(updatedJsonObject.toString()).build();
 		else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a $save (boolean, default: true) query parameter to multiple Windows endpoints to allow dry-run (preview) requests that skip persisting changes.
  * Creation/update endpoints now include explicit dry-run (200 OK) responses when $save=false and adjusted success statuses for non-persistent operations.

* **Documentation**
  * Updated Windows filter docs and examples to use OData syntax (e.g., Name eq 'MoneyBank').
  * Added a dry-run example for the Windows sales-order endpoint in the API collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->