### PR TITLE
Add ExternalTraceId support to REST background job execution #483

### DIFF
--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/test/ProcessResourceImplTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/test/ProcessResourceImplTest.java
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Project: Trek Global ERP                                                   *
+ * Copyright (C) Trek Global Corporation                			          *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ *                                                                            *
+ * Contributors:                                                              *
+ * - Elaine Tan                                                               *
+ *****************************************************************************/
+package com.trekglobal.idempiere.rest.api.v1.resource.impl.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import javax.ws.rs.core.Response;
+
+import org.compiere.model.MPInstance;
+import org.compiere.util.Env;
+import org.idempiere.test.DictionaryIDs;
+import org.idempiere.tracking.AuditTraceContext;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.trekglobal.idempiere.rest.api.json.test.RestTestCase;
+import com.trekglobal.idempiere.rest.api.v1.resource.impl.ProcessResourceImpl;
+
+public class ProcessResourceImplTest extends RestTestCase {
+
+	@Test
+	void runJobWithExternalTraceId() {
+		ProcessResourceImpl processResource = new ProcessResourceImpl();
+		
+		String externalTraceId = UUID.randomUUID().toString();
+		AuditTraceContext.setExternalTraceId(externalTraceId);				
+		try {
+			String processSlug = "c_bpartner-validate";
+			String jsonText = "{\"C_BPartner_ID\": " + DictionaryIDs.C_BPartner.SEED_FARM.id 
+					+ ", \"notification-type\": \"N\" }";
+			Response response = processResource.runJob(processSlug, jsonText);
+			assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+			String jsonString = response.getEntity().toString();
+			JsonObject jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
+			int id = jsonObject.getAsJsonObject().get("id").getAsInt();
+			assertTrue(id > 0, "Failed to create background process instance");
+			
+			MPInstance pinstance = new MPInstance(Env.getCtx(), id, null);
+	        assertEquals(id, pinstance.get_ID(), "Failed to retrieve background process instance");
+			assertEquals(externalTraceId, pinstance.getExternalTraceId(), "Unexpected ExternalTraceId");
+		} finally {
+			AuditTraceContext.clear();
+		}
+
+	}
+
+}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ProcessResourceImpl.java
@@ -57,6 +57,7 @@ import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.Trx;
 import org.compiere.util.Util;
+import org.idempiere.tracking.AuditTraceContext;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -314,6 +315,7 @@ public class ProcessResourceImpl implements ProcessResource {
 	private class BackgroundJobRunnable implements Runnable
 	{
 		private Properties m_ctx;
+		private String m_externalTraceId;
 		private ProcessInfo m_pi;
 		
 		private BackgroundJobRunnable(Properties ctx, ProcessInfo pi) 
@@ -331,6 +333,7 @@ public class ProcessResourceImpl implements ProcessResource {
 			Env.setContext(m_ctx, Env.DATE, ctx.getProperty(Env.DATE));
 			RestUtils.setSessionContextVariables(m_ctx);
 
+			m_externalTraceId = AuditTraceContext.getExternalTraceId();
 			m_pi = pi;
 		}
 		
@@ -338,9 +341,12 @@ public class ProcessResourceImpl implements ProcessResource {
 		public void run() {
 			try {
 				ServerContext.setCurrentInstance(m_ctx);
+				if (!Util.isEmpty(m_externalTraceId))
+					AuditTraceContext.setExternalTraceId(m_externalTraceId);
 				doRun();
 			} finally {
 				ServerContext.dispose();
+				AuditTraceContext.clear();
 			}
 		}
 		


### PR DESCRIPTION
Add ExternalTraceId carry to BackgroundJobRunnable in ProcessResourceImpl so that background jobs submitted via REST carry the same ExternalTraceId as the originating request.

Related to [IDEMPIERE-6910](https://idempiere.atlassian.net/browse/IDEMPIERE-6910) Add ExternalTraceId to core audit changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace context propagation for background job executions so audit trace IDs are preserved and cleared correctly during asynchronous processing.
* **Tests**
  * Added an automated test verifying that background jobs receive and persist the external trace identifier and that cleanup occurs after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->