### PR TITLE
Add DisplayType.TimestampWithTimeZone with millisecond support (DAD-2…

### DIFF
--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
@@ -77,6 +77,15 @@ public class DateTypeConverterTest extends RestTestCase {
     }
 
     @Test
+    public void toJsonValueFormatsDateCorrectlyForTimestampWithTimeZoneDisplayType() {
+        when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.TimestampWithTimeZone);
+        Date date = new Date();
+        String expected = date.toInstant().toString();
+        Object result = converter.toJsonValue(mockColumn, date);
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void toJsonValueReturnsNullForNullDate() {
         when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.Date);
         Object result = converter.toJsonValue(mockColumn, null);
@@ -102,6 +111,15 @@ public class DateTypeConverterTest extends RestTestCase {
     }
 
     @Test
+    public void fromJsonValueParsesValidTimestampStringForTimestampWithTimeZoneDisplayType() {
+        when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.TimestampWithTimeZone);
+        String timestampString = "2023-10-01T12:34:56.789Z";
+        JsonPrimitive jsonValue = new JsonPrimitive(timestampString);
+        Timestamp result = (Timestamp) converter.fromJsonValue(mockColumn, jsonValue);
+        assertEquals(timestampString, result.toInstant().toString());
+    }
+
+    @Test
     public void fromJsonValueThrowsExceptionForInvalidDateString() {
         when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.Date);
         JsonPrimitive jsonValue = new JsonPrimitive("invalid-date");
@@ -110,6 +128,18 @@ public class DateTypeConverterTest extends RestTestCase {
             fail("Expected IDempiereRestException to be thrown");
         } catch (IDempiereRestException e) {
             assertTrue(e.getTitle().contains("Invalid date"));
+        }
+    }
+
+    @Test
+    public void fromJsonValueThrowsExceptionForInvalidTimestampString() {
+        when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.TimestampWithTimeZone);
+        JsonPrimitive jsonValue = new JsonPrimitive("invalid-timestamp");
+        try {
+            converter.fromJsonValue(mockColumn, jsonValue);
+            fail("Expected IDempiereRestException to be thrown");
+        } catch (IDempiereRestException e) {
+            assertTrue(e.getTitle().contains("Invalid ISO Timestamp"));
         }
     }
 

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
@@ -150,4 +150,14 @@ public class DateTypeConverterTest extends RestTestCase {
         assertNull(result);
     }
 
+    @Test
+    public void fromJsonValueRoundTripsNanoPrecisionForTimestampWithTimeZoneDisplayType() {
+        when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.TimestampWithTimeZone);
+        String timestampString = "2023-10-01T12:34:56.123456789Z";
+        JsonPrimitive jsonValue = new JsonPrimitive(timestampString);
+        Timestamp result = (Timestamp) converter.fromJsonValue(mockColumn, jsonValue);
+        assertEquals(timestampString, result.toInstant().toString());
+        // and serialization round-trip
+        assertEquals(timestampString, converter.toJsonValue(mockColumn, result));
+    }
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -61,7 +61,7 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	public Object toJsonValue(int displayType, Date value) {
 		if (DisplayType.isTimestampWithTimeZone(displayType) && value != null) {
 			//Instant.toString will use the ISO_INSTANT_HINT format
- 			return value.toInstant().toString();
+			return value.toInstant().toString();
 		}
 
 		String pattern = getPattern(displayType);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -29,6 +29,8 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 import javax.ws.rs.core.Response.Status;
@@ -41,16 +43,16 @@ import com.google.gson.JsonElement;
 
 /**
  * 
- * Type converter for DisplayType.Date and DisplayType.DateTime
+ * Type converter for DisplayType.Date, DisplayType.DateTime and DisplayType.TimestampWithTimeZone
  * @author hengsin
  *
  */
 public class DateTypeConverter implements ITypeConverter<Date> {
-	private static final String TIMESTAMP_WITH_TIMEZONE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z' or yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 	public static final String ISO8601_DATE_PATTERN = "yyyy-MM-dd";
 	public static final String ISO8601_TIME_PATTERN = "HH:mm:ss'Z'";
 	public static final String ISO8601_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
+	private static final String ISO_INSTANT_HINT = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS]'Z'";
 	/**
 	 * 
 	 */
@@ -59,8 +61,8 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 
 	public Object toJsonValue(int displayType, Date value) {
 		if (DisplayType.isTimestampWithTimeZone(displayType) && value != null) {
-			//Instant.toString will use either "yyyy-MM-dd'T'HH:mm:ss'Z'" or "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" depending on the milliseconds value
-			return value.toInstant().toString();
+			//Instant.toString will use the ISO_INSTANT_HINT format
+ 			return value.toInstant().toString();
 		}
 
 		String pattern = getPattern(displayType);
@@ -86,12 +88,12 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	private Timestamp fromJsonValue(int displayType, JsonElement value) {
 		if (DisplayType.isTimestampWithTimeZone(displayType) && value != null) {
 			try {
-				//Instant.parse support both "yyyy-MM-dd'T'HH:mm:ss'Z'" and "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" 
+				//Instant.parse use the ISO_INSTANT_HINT format
 				return Timestamp.from(Instant.parse(value.getAsString()));
-			} catch (Exception e) {
+			} catch (DateTimeParseException e) {
 				throw new IDempiereRestException("Invalid ISO Timestamp. ", 
 					"The " + DisplayType.getDescription(displayType) 
-					+ " pattern should be: " + TIMESTAMP_WITH_TIMEZONE_PATTERN + ". Exception: " + e.getLocalizedMessage(), 
+					+ " pattern should be: " + ISO_INSTANT_HINT + ". Exception: " + e.getLocalizedMessage(), 
 					Status.BAD_REQUEST);
 			}
 		}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -28,6 +28,7 @@ package com.trekglobal.idempiere.rest.api.json;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 
 import javax.ws.rs.core.Response.Status;
@@ -45,6 +46,7 @@ import com.google.gson.JsonElement;
  *
  */
 public class DateTypeConverter implements ITypeConverter<Date> {
+	private static final String TIMESTAMP_WITH_TIMEZONE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z' or yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 	public static final String ISO8601_DATE_PATTERN = "yyyy-MM-dd";
 	public static final String ISO8601_TIME_PATTERN = "HH:mm:ss'Z'";
 	public static final String ISO8601_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
@@ -56,6 +58,11 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	}
 
 	public Object toJsonValue(int displayType, Date value) {
+		if (DisplayType.isTimestampWithTimeZone(displayType) && value != null) {
+			//Instant.toString will use either "yyyy-MM-dd'T'HH:mm:ss'Z'" or "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" depending on the milliseconds value
+			return value.toInstant().toString();
+		}
+
 		String pattern = getPattern(displayType);
 		
 		if (DisplayType.isDate(displayType) && pattern != null && value != null) {
@@ -77,6 +84,18 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	}
 
 	private Timestamp fromJsonValue(int displayType, JsonElement value) {
+		if (DisplayType.isTimestampWithTimeZone(displayType) && value != null) {
+			try {
+				//Instant.parse support both "yyyy-MM-dd'T'HH:mm:ss'Z'" and "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" 
+				return Timestamp.from(Instant.parse(value.getAsString()));
+			} catch (Exception e) {
+				throw new IDempiereRestException("Invalid ISO Timestamp. ", 
+					"The " + DisplayType.getDescription(displayType) 
+					+ " pattern should be: " + TIMESTAMP_WITH_TIMEZONE_PATTERN + ". Exception: " + e.getLocalizedMessage(), 
+					Status.BAD_REQUEST);
+			}
+		}
+
 		String pattern = getPattern(displayType);
 		
 		if (DisplayType.isDate(displayType) && pattern != null && value != null) {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -29,7 +29,6 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 


### PR DESCRIPTION
…59) #490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for timestamps with timezone using strict ISO-8601 instant format for JSON serialization and deserialization.
  * Malformed timestamp inputs now return a clear 400 Bad Request with an explanatory message.
  * Serialization consistently emits ISO-8601 instant strings for timestamps, preserving sub-second precision.

* **Tests**
  * Added unit tests covering valid, invalid and precision-preserving round-trip timestamp-with-timezone serialization/deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->