### PR TITLE
Add DisplayType.TimestampWithTimeZone with millisecond support (DAD-2…

### DIFF
--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -5660,7 +5660,106 @@
 				}
 			},
 			"response": []
-		}
+		},
+		{
+		  "name": "api/v1/models/{table name} - timestamp eq filter",
+		  "request": {
+			"method": "GET",
+			"header": [
+			  {
+				"key": "Content-Type",
+				"value": "application/json",
+				"type": "text"
+			  },
+			  {
+				"key": "Accept",
+				"value": "application/json",
+				"type": "text"
+			  },
+			  {
+				"key": "Authorization",
+				"value": "Bearer {{authToken}}",
+				"type": "text"
+			  }
+			],
+			"url": {
+			  "raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created eq '2003-01-08T15:06:11'&$select=name,created",
+			  "protocol": "{{protocol}}",
+			  "host": [
+				"{{host}}"
+			  ],
+			  "port": "{{port}}",
+			  "path": [
+				"api",
+				"v1",
+				"models",
+				"c_tax"
+			  ],
+			  "query": [
+				{
+				  "key": "$filter",
+				  "value": "created eq '2003-01-08T15:06:11'"
+				},
+				{
+				  "key": "$select",
+				  "value": "name,created",
+				  "type": "text"
+				}
+			  ]
+			},
+			"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
+		  },
+		  "response": []
+		},
+		{
+		  "name": "api/v1/models/{table name} - timestamp range filter",
+		  "request": {
+			"method": "GET",
+			"header": [
+			  {
+				"key": "Content-Type",
+				"value": "application/json",
+				"type": "text"
+			  },
+			  {
+				"key": "Accept",
+				"value": "application/json",
+				"type": "text"
+			  },
+			  {
+				"key": "Authorization",
+				"value": "Bearer {{authToken}}",
+				"type": "text"
+			  }
+			],
+			"url": {
+			  "raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'&$select=name,created",
+			  "protocol": "{{protocol}}",
+			  "host": [
+				"{{host}}"
+			  ],
+			  "port": "{{port}}",
+			  "path": [
+				"api",
+				"v1",
+				"models",
+				"c_tax"
+			  ],
+			  "query": [
+				{
+				  "key": "$filter",
+				  "value": "created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'"
+				},
+				{
+				  "key": "$select",
+				  "value": "name,created"
+				}
+			  ]
+			},
+			"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
+		  },
+		  "response": []
+		}		
 	],
 	"event": [
 		{

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/filter/ConvertedQuery.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/filter/ConvertedQuery.java
@@ -29,6 +29,8 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -104,13 +106,18 @@ public class ConvertedQuery {
 				if (parameter.contains("'"))
 					parameter = extractFromStringValue(parameter);
 
-				// ISO8601_DATETIME_PATTERN or ISO_INSTANT format
+				// ISO_INSTANT (with zone/offset) or ISO8601_DATETIME (local datetime)
 				if (parameter.contains("T") 
 					&& (DisplayType.DateTime == displayType || DisplayType.TimestampWithTimeZone == displayType)) {
 					try {
 						date = Timestamp.from(Instant.parse(parameter));
 					} catch (DateTimeParseException e) {
-						date = dateFormat.parse(parameter);
+						try {
+							LocalDateTime localDateTime = LocalDateTime.parse(parameter, DateTimeFormatter.ISO_DATE_TIME);
+							date = Timestamp.valueOf(localDateTime);
+						} catch (DateTimeParseException ex) {
+							date = dateTimeFormat.parse(parameter);
+						}
 					}
 				} else {
 					try {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/filter/ConvertedQuery.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/filter/ConvertedQuery.java
@@ -28,6 +28,8 @@ package com.trekglobal.idempiere.rest.api.json.filter;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,7 +95,7 @@ public class ConvertedQuery {
 				addParameter(new BigDecimal(parameter));
 			else if (DisplayType.isDate(displayType)) //	Timestamps
 			{
-				// Try Timestamp format - then date format
+				// Try ISO8601_DATETIME/Timestamp format - then date format
 				java.util.Date date = null;
 				SimpleDateFormat dateTimeFormat = DisplayType.getTimestampFormat_Default();
 				SimpleDateFormat dateFormat = DisplayType.getDateFormat_JDBC();
@@ -101,14 +103,25 @@ public class ConvertedQuery {
 				//If the value comes with ' remove them
 				if (parameter.contains("'"))
 					parameter = extractFromStringValue(parameter);
-				try {
-					if (displayType == DisplayType.Date) {
+
+				// ISO8601_DATETIME_PATTERN or ISO_INSTANT format
+				if (parameter.contains("T") 
+					&& (DisplayType.DateTime == displayType || DisplayType.TimestampWithTimeZone == displayType)) {
+					try {
+						date = Timestamp.from(Instant.parse(parameter));
+					} catch (DateTimeParseException e) {
 						date = dateFormat.parse(parameter);
-					} else {
-						date = dateTimeFormat.parse(parameter);
 					}
-				} catch (java.text.ParseException e) {
-					date = dateFormat.parse(parameter);
+				} else {
+					try {
+						if (displayType == DisplayType.Date) {
+							date = dateFormat.parse(parameter);
+						} else {
+							date = dateTimeFormat.parse(parameter);
+						}
+					} catch (java.text.ParseException e) {
+						date = dateFormat.parse(parameter);
+					}
 				}
 				addParameter(new Timestamp (date.getTime()));
 			}


### PR DESCRIPTION
…59) #490

- add ISO8601_DATETIME/ISO_INSTANT format support to query parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date/time parameter handling in the REST API to accept ISO‑8601 inputs while retaining fallback to legacy formats for compatibility.

* **New Features**
  * Added API examples demonstrating timestamp-based filtering (equality and half-open range) to the Postman collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->