### PR TITLE
DisplayType.DateTime is hardcoded to return UTC timestamp #495

### DIFF
--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/DateTypeConverterTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Date;
 
 import org.compiere.model.MColumn;
@@ -71,7 +72,7 @@ public class DateTypeConverterTest extends RestTestCase {
     public void toJsonValueFormatsDateCorrectlyForDateTimeDisplayType() {
         when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.DateTime);
         Date date = new Date();
-        String expected = new SimpleDateFormat(DateTypeConverter.ISO8601_DATETIME_PATTERN).format(date);
+        String expected = new SimpleDateFormat(DateTypeConverter.ISO8601_DATETIME_WITH_TIMEZONE_PATTERN).format(date);
         Object result = converter.toJsonValue(mockColumn, date);
         assertEquals(expected, result);
     }
@@ -107,7 +108,7 @@ public class DateTypeConverterTest extends RestTestCase {
         String dateTimeString = "2023-10-01T12:34:56Z";
         JsonPrimitive jsonValue = new JsonPrimitive(dateTimeString);
         Timestamp result = (Timestamp) converter.fromJsonValue(mockColumn, jsonValue);
-        assertEquals(dateTimeString, new SimpleDateFormat(DateTypeConverter.ISO8601_DATETIME_PATTERN).format(result));
+        assertEquals(dateTimeString, result.toInstant().toString());
     }
 
     @Test

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -29,8 +29,6 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 
@@ -104,7 +102,7 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 			String text = value.getAsString();
 			try {
 				// Accept ISO-8601 offsets, including trailing 'Z'
-				return Timestamp.from(OffsetDateTime.parse(text, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant());
+				return Timestamp.from(Instant.parse(text));
 			} catch (DateTimeParseException ex) {
 				// Fallback to legacy format for backward compatibility
 			}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -50,6 +50,7 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	public static final String ISO8601_DATE_PATTERN = "yyyy-MM-dd";
 	public static final String ISO8601_TIME_PATTERN = "HH:mm:ss'Z'";
 	public static final String ISO8601_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+	public static final String ISO8601_DATETIME_WITH_TIMEZONE_PATTERN = "yyyy-MM-dd'T'HH:mm:ssXXX";
 
 	private static final String ISO_INSTANT_HINT = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSSSSS]'Z'";
 	/**
@@ -64,7 +65,7 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 			return value.toInstant().toString();
 		}
 
-		String pattern = getPattern(displayType);
+		String pattern = getPattern(displayType, true);
 		
 		if (DisplayType.isDate(displayType) && pattern != null && value != null) {
 			String formatted = new SimpleDateFormat(pattern).format(value);
@@ -97,7 +98,7 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 			}
 		}
 
-		String pattern = getPattern(displayType);
+		String pattern = getPattern(displayType, false);
 		
 		if (DisplayType.isDate(displayType) && pattern != null && value != null) {
 			Date parsed = null;
@@ -125,15 +126,19 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 	/**
 	 * Returns an ISO-8601 format pattern according to the display type.
 	 * @param displayType Display Type
+	 * @param output whether the pattern is for output or input
 	 * @return formatting pattern
 	 */
-	private String getPattern(int displayType) {
+	private String getPattern(int displayType, boolean output) {
 		if (displayType == DisplayType.Date)
 			return ISO8601_DATE_PATTERN;
 		else if (displayType == DisplayType.Time)
 			return ISO8601_TIME_PATTERN;
 		else if (displayType == DisplayType.DateTime)
-			return ISO8601_DATETIME_PATTERN;
+			if (output)
+				return ISO8601_DATETIME_WITH_TIMEZONE_PATTERN;
+			else
+				return ISO8601_DATETIME_PATTERN;
 		else
 			return null;
 	}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DateTypeConverter.java
@@ -29,6 +29,8 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 
@@ -95,6 +97,16 @@ public class DateTypeConverter implements ITypeConverter<Date> {
 					"The " + DisplayType.getDescription(displayType) 
 					+ " pattern should be: " + ISO_INSTANT_HINT + ". Exception: " + e.getLocalizedMessage(), 
 					Status.BAD_REQUEST);
+			}
+		}
+
+		if (displayType == DisplayType.DateTime && value != null) {
+			String text = value.getAsString();
+			try {
+				// Accept ISO-8601 offsets, including trailing 'Z'
+				return Timestamp.from(OffsetDateTime.parse(text, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant());
+			} catch (DateTimeParseException ex) {
+				// Fallback to legacy format for backward compatibility
 			}
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API responses now emit date/time values in timezone‑aware ISO‑8601 format so offsets (including "Z") are handled consistently.
  * Incoming date/time parsing now accepts ISO‑8601 with offsets first and falls back to legacy formats when needed, improving compatibility and reducing parsing errors across clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->