### PR TITLE
Use status 400 for field validation errors (DAD-379) #497

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -566,7 +566,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 	}
 	
 	private boolean setDefaultValue(PO po, MColumn column, MRestViewColumn viewColumn) {
-		if (!column.isVirtualColumn()) {
+		if (!column.isVirtualColumn() && !column.isKey()
+			&& !column.getColumnName().equalsIgnoreCase(PO.getUUIDColumnName(po.get_TableName()))) {
 			GridFieldVO vo = GridFieldVO.createParameter(Env.getCtx(), windowNo, 0, 0, column.getAD_Column_ID(), column.getColumnName(), column.getName(), 
 						DisplayType.isLookup(column.getAD_Reference_ID()) 
 						? (DisplayType.isText(column.getAD_Reference_ID()) || DisplayType.isList(column.getAD_Reference_ID()) ? DisplayType.String : DisplayType.ID) 

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -42,11 +42,8 @@ import org.compiere.model.MSysConfig;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
 import org.compiere.model.POInfo;
-import org.compiere.util.DefaultEvaluatee;
-import org.compiere.util.DefaultEvaluatee.DataProvider;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
-import org.compiere.util.Evaluator;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
 import org.osgi.service.component.annotations.Component;
@@ -201,7 +198,6 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 		Set<String> jsonFields = json.keySet();
 		populateContextFromPO(json, view, po);
 		
-		List<String> mandatoryColumns = new ArrayList<>();
 		//loops through columns from view or PO definition
 		MRestViewColumn[] viewColumns = view != null ? view.getColumns() : null;
 		int count = view != null ? viewColumns.length : poInfo.getColumnCount(); 
@@ -220,7 +216,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 			if (jsonPath != null && jsonPath.length > 1)
 				propertyName = jsonPath[0];
 			if (!jsonFields.contains(propertyName) && (viewColumns != null || !jsonFields.contains(columnName))) {
-				setDefaultValue(po, column, viewColumn, propertyName, json, mandatoryColumns);
+				setDefaultValue(po, column, viewColumn);
 				continue;
 			}
 			
@@ -228,7 +224,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 			if (field == null && viewColumns == null)
 				field = json.get(columnName);
 			if (field == null) {
-				setDefaultValue(po, column, viewColumn, propertyName, json, mandatoryColumns);
+				setDefaultValue(po, column, viewColumn);
 				continue;
 			}
 			//nested json value object
@@ -242,7 +238,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 					field = valueObject.get(jsonPath[p]);
 				}
 				if (field == null) {
-					setDefaultValue(po, column, viewColumn, propertyName, json, mandatoryColumns);
+					setDefaultValue(po, column, viewColumn);
 					continue;
 				}
 			}
@@ -252,12 +248,12 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				continue;
 			if (viewColumn != null && !Util.isEmpty(viewColumn.getReadOnlyLogic(), true)) {
 				if (viewColumn.isReadOnly(json)) {
-					setDefaultValue(po, column, viewColumn, propertyName, json, mandatoryColumns);
+					setDefaultValue(po, column, viewColumn);
 					continue;
 				}
 			}
 			else if (! isUpdatable(column, false, po)) {
-				setDefaultValue(po, column, viewColumn, propertyName, json, mandatoryColumns);
+				setDefaultValue(po, column, viewColumn);
 				continue;
 			}
 			if (   value != null
@@ -270,58 +266,9 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			po.set_ValueOfColumn(column.getAD_Column_ID(), value);
-			if (value == null) {
-				if (viewColumn != null && viewColumn.isMandatory(json)) {
-					mandatoryColumns.add(propertyName);
-				} else {
-					doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
-				}
-			}
-		}
-		
-		if (!mandatoryColumns.isEmpty()) {
-			StringBuilder error = new StringBuilder();
-			for(String mandatoryColumn : mandatoryColumns) {
-				error.append(mandatoryColumn).append(", ");
-			}
-			error.delete(error.length()-2, error.length());
-			throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
-						Msg.getMsg(Env.getCtx(), "FillMandatory") + error.toString(), Status.BAD_REQUEST);
 		}
 		
 		return po;
-	}
-
-	private void doColumnMandatoryValidation(JsonObject json, List<String> mandatoryColumns, MColumn column,
-			String propertyName) {
-		String mandatoryLogic = column.getMandatoryLogic();
-		if (!Util.isEmpty(mandatoryLogic, true)) {
-			if (isMandatory(column, json, mandatoryLogic))
-				mandatoryColumns.add(propertyName);
-		} else if (column.isMandatory()) {
-			mandatoryColumns.add(propertyName);
-		}
-	}
-
-	/**
-	 * Set default value for column
-	 * @param po
-	 * @param column
-	 * @param viewColumn
-	 * @param propertyName input property name
-	 * @param json input json object
-	 * @param mandatoryColumns list to store mandatory columns that are not filled
-	 */
-	private void setDefaultValue(PO po, MColumn column, MRestViewColumn viewColumn, String propertyName,
-			JsonObject json, List<String> mandatoryColumns) {
-		boolean set = setDefaultValue(po, column, viewColumn);
-		if (!set) {
-			if (viewColumn != null && viewColumn.isMandatory(json))
-				mandatoryColumns.add(propertyName);
-			else if (!column.isKey() && !"Created".equals(column.getColumnName()) && !"Updated".equals(column.getColumnName()) 
-				&& !"CreatedBy".equals(column.getColumnName()) && !"UpdatedBy".equals(column.getColumnName()))
-				doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
-		}
 	}
 
 	@Override
@@ -337,7 +284,6 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 		Set<String> jsonFields = json.keySet();
 		populateContextFromPO(json, view, po);
 
-		List<String> mandatoryColumns = new ArrayList<>();
 		//loops through columns from view or PO definition
 		MRestViewColumn[] viewColumns = view != null ? view.getColumns() : null;
 		int count = view != null ? viewColumns.length : poInfo.getColumnCount();
@@ -399,26 +345,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			
-			if (value == null)
-			{
-				if (viewColumn != null && viewColumn.isMandatory(json)) {
-					mandatoryColumns.add(propertyName);
-				} else {
-					doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
-				}
-			}
-			else
-				po.set_ValueOfColumn(column.getAD_Column_ID(), value);
-		}
-		
-		if (!mandatoryColumns.isEmpty()) {
-			StringBuilder error = new StringBuilder();
-			for(String mandatoryColumn : mandatoryColumns) {
-				error.append(mandatoryColumn).append(", ");
-			}
-			error.delete(error.length()-2, error.length());
-			throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
-						Msg.getMsg(Env.getCtx(), "FillMandatory") + error.toString(), Status.BAD_REQUEST);
+			po.set_ValueOfColumn(column.getAD_Column_ID(), value);
 		}
 		
 		return po;
@@ -634,7 +561,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 	}
 	
 	private boolean setDefaultValue(PO po, MColumn column, MRestViewColumn viewColumn) {
-		if (!column.isVirtualColumn() && (!Util.isEmpty(column.getDefaultValue(), true) || (viewColumn != null && !Util.isEmpty(viewColumn.getDefaultValue(), true)))) {
+		if (!column.isVirtualColumn()) {
 			GridFieldVO vo = GridFieldVO.createParameter(Env.getCtx(), windowNo, 0, 0, column.getAD_Column_ID(), column.getColumnName(), column.getName(), 
 						DisplayType.isLookup(column.getAD_Reference_ID()) 
 						? (DisplayType.isText(column.getAD_Reference_ID()) || DisplayType.isList(column.getAD_Reference_ID()) ? DisplayType.String : DisplayType.ID) 
@@ -695,50 +622,6 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				Env.setContext(Env.getCtx(), windowNo, columnName, value.toString());
 		}
     }
-
-	/**
-	 * Check if column is mandatory
-	 * @param column column to check
-	 * @param jsonObject json object
-	 * @param mandatoryLogic mandatory logic
-	 * @return true if column is mandatory, false otherwise
-	 */
-	public static boolean isMandatory(MColumn column, JsonObject jsonObject, String mandatoryLogic) {
-		if (Util.isEmpty(mandatoryLogic, true))
-			return false;
-		
-		if (mandatoryLogic.startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX))
-		{
-			return Evaluator.parseSQLLogic(mandatoryLogic, Env.getCtx(), 0, -1, column.getColumnName());
-		}
-		else
-		{
-			DataProvider provider = new DataProvider() {
-
-				@Override
-				public Object getValue(String columnName) {
-					JsonElement element = jsonObject.get(columnName);
-					return element == null ? null : element.getAsString();
-				}
-
-				@Override
-				public Object getProperty(String propertyName) {
-					return null;
-				}
-
-				@Override
-				public MColumn getColumn(String columnName) {
-					return null;
-				}
-
-				@Override
-				public String getTrxName() {
-					return null;
-				}
-				
-			};
-			DefaultEvaluatee evaluatee = new DefaultEvaluatee(provider);
-			return Evaluator.evaluateLogic(evaluatee, mandatoryLogic);
-		}
-	}
 }
+
+

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -34,7 +34,6 @@ import java.util.Set;
 
 import javax.ws.rs.core.Response.Status;
 
-import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.GridField;
 import org.compiere.model.GridFieldVO;
 import org.compiere.model.MColumn;
@@ -388,13 +387,15 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 
 		if (validateUpdateable && !column.isUpdateable()) {
 			if (errorOnNonUpdatable)
-				throw new AdempiereException("Cannot update column " + column.getColumnName());
+				throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update column " + column.getColumnName(), Status.BAD_REQUEST);
 			else
 				return false;
 		}
 		if (column.isVirtualColumn()) {
 			if (errorOnNonUpdatable)
-				throw new AdempiereException("Cannot update virtual column " + column.getColumnName());
+				throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update virtual column " + column.getColumnName(), Status.BAD_REQUEST);
 			else
 				return false;
 		}
@@ -402,7 +403,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 		if (! allowUpdateSecure) {
 			if (column.isSecure() || column.isEncrypted()) {
 				if (errorOnNonUpdatable)
-					throw new AdempiereException("Cannot update secure/encrypted column " + column.getColumnName());
+					throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update secure/encrypted column " + column.getColumnName(), Status.BAD_REQUEST);
 				else
 					return false;
 			}
@@ -410,7 +412,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 
 		if (!RestUtils.hasRoleColumnAccess(column.getAD_Table_ID(), column.getAD_Column_ID(), false)) {
 			if (errorOnNonUpdatable)
-				throw new AdempiereException("No access to update column " + column.getColumnName());
+				throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"No access to update column " + column.getColumnName(), Status.BAD_REQUEST);
 			else
 				return false;
 		}
@@ -420,7 +423,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				if (po.get_ValueAsBoolean("processed")) {
 					if (!column.isAlwaysUpdateable()) {
 						if (errorOnNonUpdatable)
-							throw new AdempiereException("Cannot update " + column.getColumnName() + " on processed record");
+							throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update " + column.getColumnName() + " on processed record", Status.BAD_REQUEST);
 						else
 							return false;
 					}
@@ -430,7 +434,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				if (po.get_ValueAsBoolean("posted")) {
 					if (!column.isAlwaysUpdateable()) {
 						if (errorOnNonUpdatable)
-							throw new AdempiereException("Cannot update " + column.getColumnName() + " on posted record");
+							throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update " + column.getColumnName() + " on posted record", Status.BAD_REQUEST);
 						else
 							return false;
 					}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -270,7 +270,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			po.set_ValueOfColumn(column.getAD_Column_ID(), value);
-			if (value == null && viewColumn != null && viewColumn.isMandatory(json)) {
+			if (value == null) {
 				if (viewColumn != null && viewColumn.isMandatory(json)) {
 					mandatoryColumns.add(propertyName);
 				} else {
@@ -381,7 +381,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 			if (viewColumn != null && !Util.isEmpty(viewColumn.getReadOnlyLogic(), true)) {
 				if (viewColumn.isReadOnly(json)) {
 					if (MSysConfig.getBooleanValue("REST_ERROR_ON_NON_UPDATABLE_COLUMN", true))
-						throw new AdempiereException("Cannot update column " + viewColumn.getName());
+						throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Cannot update column " + viewColumn.getName(), Status.BAD_REQUEST);
 					else
 						continue;
 				}
@@ -398,19 +399,26 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			
-			if (value == null && viewColumn != null && viewColumn.isMandatory(json))
-				mandatoryColumns.add(propertyName);
+			if (value == null)
+			{
+				if (viewColumn != null && viewColumn.isMandatory(json)) {
+					mandatoryColumns.add(propertyName);
+				} else {
+					doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
+				}
+			}
 			else
 				po.set_ValueOfColumn(column.getAD_Column_ID(), value);
 		}
 		
 		if (!mandatoryColumns.isEmpty()) {
-			StringBuilder error = new StringBuilder("Field is mandatory: ");
+			StringBuilder error = new StringBuilder();
 			for(String mandatoryColumn : mandatoryColumns) {
 				error.append(mandatoryColumn).append(", ");
 			}
 			error.delete(error.length()-2, error.length());
-			throw new AdempiereException(error.toString());
+			throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+						Msg.getMsg(Env.getCtx(), "FillMandatory") + error.toString(), Status.BAD_REQUEST);
 		}
 		
 		return po;

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.GridField;
 import org.compiere.model.GridFieldVO;
@@ -40,8 +42,12 @@ import org.compiere.model.MSysConfig;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
 import org.compiere.model.POInfo;
+import org.compiere.util.DefaultEvaluatee;
+import org.compiere.util.DefaultEvaluatee.DataProvider;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
+import org.compiere.util.Evaluator;
+import org.compiere.util.Msg;
 import org.compiere.util.Util;
 import org.osgi.service.component.annotations.Component;
 
@@ -264,20 +270,37 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				}
 			}
 			po.set_ValueOfColumn(column.getAD_Column_ID(), value);
-			if (value == null && viewColumn != null && viewColumn.isMandatory(json))
-				mandatoryColumns.add(propertyName);
+			if (value == null && viewColumn != null && viewColumn.isMandatory(json)) {
+				if (viewColumn != null && viewColumn.isMandatory(json)) {
+					mandatoryColumns.add(propertyName);
+				} else {
+					doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
+				}
+			}
 		}
 		
 		if (!mandatoryColumns.isEmpty()) {
-			StringBuilder error = new StringBuilder("Mandatory fields missing: ");
+			StringBuilder error = new StringBuilder();
 			for(String mandatoryColumn : mandatoryColumns) {
 				error.append(mandatoryColumn).append(", ");
 			}
 			error.delete(error.length()-2, error.length());
-			throw new AdempiereException(error.toString());
+			throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+						Msg.getMsg(Env.getCtx(), "FillMandatory") + error.toString(), Status.BAD_REQUEST);
 		}
 		
 		return po;
+	}
+
+	private void doColumnMandatoryValidation(JsonObject json, List<String> mandatoryColumns, MColumn column,
+			String propertyName) {
+		String mandatoryLogic = column.getMandatoryLogic();
+		if (!Util.isEmpty(mandatoryLogic, true)) {
+			if (isMandatory(column, json, mandatoryLogic))
+				mandatoryColumns.add(propertyName);
+		} else if (column.isMandatory()) {
+			mandatoryColumns.add(propertyName);
+		}
 	}
 
 	/**
@@ -292,8 +315,13 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 	private void setDefaultValue(PO po, MColumn column, MRestViewColumn viewColumn, String propertyName,
 			JsonObject json, List<String> mandatoryColumns) {
 		boolean set = setDefaultValue(po, column, viewColumn);
-		if (!set && viewColumn != null && viewColumn.isMandatory(json))
-			mandatoryColumns.add(propertyName);
+		if (!set) {
+			if (viewColumn != null && viewColumn.isMandatory(json))
+				mandatoryColumns.add(propertyName);
+			else if (!column.isKey() && !"Created".equals(column.getColumnName()) && !"Updated".equals(column.getColumnName()) 
+				&& !"CreatedBy".equals(column.getColumnName()) && !"UpdatedBy".equals(column.getColumnName()))
+				doColumnMandatoryValidation(json, mandatoryColumns, column, propertyName);
+		}
 	}
 
 	@Override
@@ -536,26 +564,31 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 								StringBuilder error = new StringBuilder("Wrong name for column ")
 										.append(errorPath).append(", you must use ")
 										.append(optional.get().getName());
-								throw new AdempiereException(error.toString());
+								throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+									error.toString(), Status.BAD_REQUEST);
 							} else {
-								throw new AdempiereException("Column " + errorPath + " does not exist");
+								throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+									"Column " + errorPath + " does not exist", Status.BAD_REQUEST);
 							}
 						}
 						int colIdx = po.get_ColumnIndex(columnName);
 						if (colIdx < 0)
-							throw new AdempiereException("Column " + jsonField + " does not exist");
+							throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+									"Column " + jsonField + " does not exist", Status.BAD_REQUEST);
 					}					
 					continue;
 				}
 				int colIdx = po.get_ColumnIndex(columnName);
 				if (colIdx < 0)
-					throw new AdempiereException("Column " + jsonField + " does not exist");
+					throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Column " + jsonField + " does not exist", Status.BAD_REQUEST);
 				columnName = po.get_ColumnName(colIdx);
 				
 				String propertyName = TypeConverterUtils.toPropertyName(columnName);
 				if (! jsonField.equals(propertyName) && !jsonField.equals(columnName))
-					throw new AdempiereException("Wrong name for column " + jsonField + ", you must use " + propertyName +
-							(propertyName.equals(columnName) ? "" : " or " + columnName));
+					throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"),
+							"Wrong name for column " + jsonField + ", you must use " + propertyName +
+							(propertyName.equals(columnName) ? "" : " or " + columnName), Status.BAD_REQUEST);
 			}
 		}
 	}
@@ -654,4 +687,50 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				Env.setContext(Env.getCtx(), windowNo, columnName, value.toString());
 		}
     }
+
+	/**
+	 * Check if column is mandatory
+	 * @param column column to check
+	 * @param jsonObject json object
+	 * @param mandatoryLogic mandatory logic
+	 * @return true if column is mandatory, false otherwise
+	 */
+	public static boolean isMandatory(MColumn column, JsonObject jsonObject, String mandatoryLogic) {
+		if (Util.isEmpty(mandatoryLogic, true))
+			return false;
+		
+		if (mandatoryLogic.startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX))
+		{
+			return Evaluator.parseSQLLogic(mandatoryLogic, Env.getCtx(), 0, -1, column.getColumnName());
+		}
+		else
+		{
+			DataProvider provider = new DataProvider() {
+
+				@Override
+				public Object getValue(String columnName) {
+					JsonElement element = jsonObject.get(columnName);
+					return element == null ? null : element.getAsString();
+				}
+
+				@Override
+				public Object getProperty(String propertyName) {
+					return null;
+				}
+
+				@Override
+				public MColumn getColumn(String columnName) {
+					return null;
+				}
+
+				@Override
+				public String getTrxName() {
+					return null;
+				}
+				
+			};
+			DefaultEvaluatee evaluatee = new DefaultEvaluatee(provider);
+			return Evaluator.evaluateLogic(evaluatee, mandatoryLogic);
+		}
+	}
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ResponseUtils.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ResponseUtils.java
@@ -61,21 +61,17 @@ public class ResponseUtils {
 	public static Response getResponseErrorFromException(Exception ex, String title, String detailText) {
 		Status status = Status.INTERNAL_SERVER_ERROR;
 		IDempiereRestException restException = findRestException(ex);
+		String msg = ex.getMessage();
 		if (restException != null) {
 			status = restException.getErrorResponseStatus();
 			title = restException.getTitle();			
+			msg = restException.getMessage();
 		}
 
 		// Handle formatting issues with error message from model validation events
-		String msg = ex.getMessage();
 		if (msg != null) {
 			if (msg.endsWith("<br>")) {
 				msg = msg.substring(0, msg.length() - 4);
-			}
-			if (status == Status.BAD_REQUEST) {
-				if (msg.startsWith("Error: ") && msg.indexOf(":", 8) > 0) {
-					msg = msg.substring(7);
-				}
 			}
 		}
 		log.log(Level.SEVERE, msg, ex);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ResponseUtils.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ResponseUtils.java
@@ -42,15 +42,44 @@ public class ResponseUtils {
 		return getResponseErrorFromException(ex, title, "");
 	}
 	
+	private static IDempiereRestException findRestException(Throwable ex) {
+		if (ex == null)
+			return null;
+		if (ex instanceof IDempiereRestException)
+			return (IDempiereRestException) ex;
+		
+		Throwable cause = ex.getCause();
+		while (cause != null) {
+			if (cause instanceof IDempiereRestException)
+				return (IDempiereRestException) cause;
+			cause = cause.getCause();
+		}
+		
+		return null;
+	}
+	
 	public static Response getResponseErrorFromException(Exception ex, String title, String detailText) {
 		Status status = Status.INTERNAL_SERVER_ERROR;
-		if (ex instanceof IDempiereRestException) {
-			status = ((IDempiereRestException) ex).getErrorResponseStatus();
-			title = ((IDempiereRestException) ex).getTitle();
+		IDempiereRestException restException = findRestException(ex);
+		if (restException != null) {
+			status = restException.getErrorResponseStatus();
+			title = restException.getTitle();			
 		}
 
-		log.log(Level.SEVERE, ex.getMessage(), ex);
-		return getResponseError(status, title, detailText, ex.getMessage());
+		// Handle formatting issues with error message from model validation events
+		String msg = ex.getMessage();
+		if (msg != null) {
+			if (msg.endsWith("<br>")) {
+				msg = msg.substring(0, msg.length() - 4);
+			}
+			if (status == Status.BAD_REQUEST) {
+				if (msg.startsWith("Error: ") && msg.indexOf(":", 8) > 0) {
+					msg = msg.substring(7);
+				}
+			}
+		}
+		log.log(Level.SEVERE, msg, ex);
+		return getResponseError(status, title, detailText, msg);
 	}
 	
 	public static Response getResponseError(Status status, String title, String text1, String text2) {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRestViewColumn.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRestViewColumn.java
@@ -40,7 +40,7 @@ import org.idempiere.cache.ImmutablePOSupport;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.trekglobal.idempiere.rest.api.json.DefaultPOSerializer;
+import com.trekglobal.idempiere.rest.api.v1.resource.impl.ModelResourceImpl;
 
 public class MRestViewColumn extends X_REST_ViewColumn implements ImmutablePOSupport {
 
@@ -141,9 +141,6 @@ public class MRestViewColumn extends X_REST_ViewColumn implements ImmutablePOSup
 		if (Util.isEmpty(mandatoryLogic, true))
 			mandatoryLogic = column.getMandatoryLogic();
 		
-		if (Util.isEmpty(mandatoryLogic, true))
-			return column.isMandatory();
-		
-		return DefaultPOSerializer.isMandatory(column, json, mandatoryLogic);
+		return ModelResourceImpl.isMandatory(column, json, mandatoryLogic);
 	}
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRestViewColumn.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/model/MRestViewColumn.java
@@ -40,6 +40,7 @@ import org.idempiere.cache.ImmutablePOSupport;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.trekglobal.idempiere.rest.api.json.DefaultPOSerializer;
 
 public class MRestViewColumn extends X_REST_ViewColumn implements ImmutablePOSupport {
 
@@ -135,41 +136,14 @@ public class MRestViewColumn extends X_REST_ViewColumn implements ImmutablePOSup
 	 * @return true if mandatory logic is satisfied
 	 */
 	public boolean isMandatory(JsonObject json) {
-		if (Util.isEmpty(getMandatoryLogic(), true))
-			return false;
+		String mandatoryLogic = getMandatoryLogic();
+		MColumn column = MColumn.get(getAD_Column_ID());
+		if (Util.isEmpty(mandatoryLogic, true))
+			mandatoryLogic = column.getMandatoryLogic();
 		
-		if (getMandatoryLogic().startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX))
-		{
-			return Evaluator.parseSQLLogic(getMandatoryLogic(), Env.getCtx(), 0, -1, MColumn.getColumnName(Env.getCtx(), getAD_Column_ID()));
-		}
-		else
-		{
-			DataProvider provider = new DataProvider() {
-
-				@Override
-				public Object getValue(String columnName) {
-					JsonElement element = json.get(columnName);
-					return element == null ? null : element.getAsString();
-				}
-
-				@Override
-				public Object getProperty(String propertyName) {
-					return null;
-				}
-
-				@Override
-				public MColumn getColumn(String columnName) {
-					return null;
-				}
-
-				@Override
-				public String getTrxName() {
-					return null;
-				}
-				
-			};
-			DefaultEvaluatee evaluatee = new DefaultEvaluatee(provider);
-			return Evaluator.evaluateLogic(evaluatee, getMandatoryLogic());
-		}
+		if (Util.isEmpty(mandatoryLogic, true))
+			return column.isMandatory();
+		
+		return DefaultPOSerializer.isMandatory(column, json, mandatoryLogic);
 	}
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/auth/filter/RequestFilter.java
@@ -207,6 +207,8 @@ public class RequestFilter implements ContainerRequestFilter {
 			if (!user.isActive())
 				throw new JWTVerificationException("User is inactive");
 			Env.setContext(Env.getCtx(), Env.AD_USER_ID, claim.asInt());
+			Env.setContext(Env.getCtx(), Env.AD_USER_NAME, user.getName() );
+			Env.setContext(Env.getCtx(), Env.SALESREP_ID, claim.asInt());
 		}
 		claim = jwt.getClaim(LoginClaims.AD_Role_ID.name());
 		int AD_Role_ID = 0;

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,28 +45,37 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.DatatypeConverter;
 
+import org.adempiere.base.event.EventHelper;
 import org.adempiere.base.event.EventManager;
 import org.adempiere.base.event.EventProperty;
 import org.adempiere.base.event.IEventManager;
+import org.adempiere.base.event.IEventTopics;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.CrossTenantException;
 import org.compiere.model.MAttachment;
 import org.compiere.model.MAttachmentEntry;
+import org.compiere.model.MColumn;
 import org.compiere.model.MTable;
 import org.compiere.model.MWindow;
 import org.compiere.model.PO;
+import org.compiere.model.POInfo;
 import org.compiere.model.Query;
 import org.compiere.process.DocAction;
 import org.compiere.process.ProcessInfo;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
+import org.compiere.util.DefaultEvaluatee;
+import org.compiere.util.DefaultEvaluatee.DataProvider;
+import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
+import org.compiere.util.Evaluator;
 import org.compiere.util.MimeType;
 import org.compiere.util.Msg;
 import org.compiere.util.Trx;
 import org.compiere.util.Util;
 import org.compiere.wf.MWorkflow;
 import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -84,6 +94,7 @@ import com.trekglobal.idempiere.rest.api.json.expand.ExpandUtils;
 import com.trekglobal.idempiere.rest.api.json.filter.ConvertedQuery;
 import com.trekglobal.idempiere.rest.api.json.filter.IQueryConverter;
 import com.trekglobal.idempiere.rest.api.model.MRestView;
+import com.trekglobal.idempiere.rest.api.model.MRestViewColumn;
 import com.trekglobal.idempiere.rest.api.model.MRestViewRelated;
 import com.trekglobal.idempiere.rest.api.util.ThreadLocalTrx;
 import com.trekglobal.idempiere.rest.api.v1.resource.ModelResource;
@@ -434,9 +445,22 @@ public class ModelResourceImpl implements ModelResource {
 				return ResponseUtils.getResponseError(Status.FORBIDDEN, "Update error", "Role does not have access","");
 
 			po.set_TrxName(trx.getTrxName());
+
+			// Handler for mandatory fields validation
+			MRestView finalView = view;
+			JsonObject finalJsonObject = jsonObject;
+			EventHandler eventHandler = (Event evt) ->{
+				PO eventPO = EventHelper.getPO(evt);
+				if (eventPO == po) {
+					validateMandatoryColumns(po, finalView, finalJsonObject, evt);
+				}
+			};
+
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, true);
 			try {
 				po.validForeignKeysEx();
+				String tableFilter = "(tableName="+tableName+")";
+				EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);
 				po.saveEx();
 				fireRestSaveEvent(po, PO_AFTER_REST_SAVE, true);
 			} catch (CrossTenantException e) {
@@ -446,6 +470,8 @@ public class ModelResourceImpl implements ModelResource {
 			} catch (Exception ex) {
 				trx.rollback();
 				return ResponseUtils.getResponseErrorFromException(ex, "Save error");
+			} finally {
+				EventManager.getInstance().unregister(eventHandler);
 			}
 			Map<String, JsonArray> detailMap = new LinkedHashMap<>();
 			Set<String> fields = jsonObject.keySet();
@@ -546,8 +572,24 @@ public class ModelResourceImpl implements ModelResource {
 								childPO.set_ValueOfColumn(RestUtils.getKeyColumnName(po.get_TableName()), po.get_ID());
 							
 							fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, true);
+
+							// Register handler for mandatory fields validation
+							JsonObject finalChildJsonObject = childJsonObject;
+							EventHandler eventHandler = (Event evt) ->{
+								PO eventPO = EventHelper.getPO(evt);
+								if (eventPO == childPO) {
+									validateMandatoryColumns(childPO, finalChildView, finalChildJsonObject, evt);
+								}
+							};
+							String tableFilter = "(tableName="+childTable.getTableName()+")";
+							EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);
+							
 							childPO.validForeignKeysEx();
-							childPO.saveEx();
+							try {
+								childPO.saveEx();
+							} finally {
+								EventManager.getInstance().unregister(eventHandler);
+							}
 							fireRestSaveEvent(childPO, PO_AFTER_REST_SAVE, true);
 							childJsonObject = childSerializer.toJson(childPO, finalChildView);
 							JsonObject newChildJsonObject = e.getAsJsonObject();
@@ -619,8 +661,22 @@ public class ModelResourceImpl implements ModelResource {
 			JsonObject jsonObject = gson.fromJson(jsonText, JsonObject.class);
 			IPOSerializer serializer = IPOSerializer.getPOSerializer(tableName, MTable.getClass(tableName));
 			serializer.setWindowNo(windowNo);
-			po = serializer.fromJson(jsonObject, po, view);
+			po = serializer.fromJson(jsonObject, po, view);			
 			po.set_TrxName(trx.getTrxName());
+
+			// Register handler for mandatory fields validation
+			PO finalPO = po;
+			MRestView finalView = view;
+			JsonObject finalJsonObject = jsonObject;
+			EventHandler eventHandler = (Event evt) ->{
+				PO eventPO = EventHelper.getPO(evt);
+				if (eventPO == finalPO) {
+					validateMandatoryColumns(finalPO, finalView, finalJsonObject, evt);
+				}
+			};
+			String tableFilter = "(tableName="+tableName+")";
+			EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, tableFilter, eventHandler);
+
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, false);
 			try {
 				po.validForeignKeysEx();
@@ -633,6 +689,8 @@ public class ModelResourceImpl implements ModelResource {
 			}  catch (Exception ex) {
 				trx.rollback();
 				return ResponseUtils.getResponseErrorFromException(ex, "Save error");
+			} finally {
+				EventManager.getInstance().unregister(eventHandler);
 			}
 			
 			Map<String, JsonArray> detailMap = new LinkedHashMap<>();
@@ -690,9 +748,28 @@ public class ModelResourceImpl implements ModelResource {
 									if (delete) {
 										childPO.deleteEx(true);
 									} else {
+										// Register event handler for mandatory validation
+										PO finalChilPo = childPO;
+										JsonObject finalChildJsonObject = childJsonObject;
+										EventHandler childEventHandler = (Event evt) ->{
+											PO eventPO = EventHelper.getPO(evt);
+											if (eventPO == finalChilPo) {
+												validateMandatoryColumns(finalChilPo, finalChildView, finalChildJsonObject, evt);
+											}
+										};
+										String childTableFilter = "(tableName="+childTable.getTableName()+")";
+										if (childPO.is_new())
+											EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, childTableFilter, childEventHandler);
+										else
+											EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, childTableFilter, childEventHandler);
+
 										fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, false);
 										childPO.validForeignKeysEx();
-										childPO.saveEx();
+										try {
+											childPO.saveEx();
+										} finally {
+											EventManager.getInstance().unregister(childEventHandler);
+										}
 										fireRestSaveEvent(childPO, PO_AFTER_REST_SAVE, false);
 										childJsonObject = serializer.toJson(childPO, finalChildView);
 										savedArray.add(childJsonObject);
@@ -1288,6 +1365,128 @@ public class ModelResourceImpl implements ModelResource {
 		builder.append(" ".repeat(10)).append("description: record uuid\n");
 		
 		YAMLSchema.addTableProperties(table, builder, 8);
+	}
+
+	/**
+	 * Check if column is mandatory
+	 * @param column column to check
+	 * @param jsonObject json object
+	 * @param mandatoryLogic mandatory logic
+	 * @return true if column is mandatory, false otherwise
+	 */
+	public static boolean isMandatory(MColumn column, JsonObject jsonObject, String mandatoryLogic) {
+		if (!Util.isEmpty(mandatoryLogic, true))
+		{
+			boolean retValue = false;
+			if (mandatoryLogic.startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX))
+			{
+				retValue = Evaluator.parseSQLLogic(mandatoryLogic, Env.getCtx(), 0, -1, column.getColumnName());
+			}
+			else
+			{
+				DataProvider provider = new DataProvider() {
+	
+					@Override
+					public Object getValue(String columnName) {
+						JsonElement element = jsonObject.get(columnName);
+						return element == null ? null : element.getAsString();
+					}
+	
+					@Override
+					public Object getProperty(String propertyName) {
+						return null;
+					}
+	
+					@Override
+					public MColumn getColumn(String columnName) {
+						return null;
+					}
+	
+					@Override
+					public String getTrxName() {
+						return null;
+					}
+					
+				};
+				DefaultEvaluatee evaluatee = new DefaultEvaluatee(provider);
+				retValue = Evaluator.evaluateLogic(evaluatee, mandatoryLogic);
+			}
+			if (retValue)
+				return true;
+		}
+
+		if (column.isVirtualColumn())
+			return false;
+
+		// Adapted from GridField.isMandatory
+		String columnName = column.getColumnName();
+		if ((column.isKey() && columnName.endsWith("_ID"))
+			|| columnName.startsWith("Created") || columnName.startsWith("Updated")
+			|| "Value".equals(columnName) 
+			|| "DocumentNo".equals(columnName)
+			|| "M_AttributeSetInstance_ID".equals(columnName)
+			|| DisplayType.YesNo == column.getAD_Reference_ID()
+			|| columnName.equalsIgnoreCase(PO.getUUIDColumnName(MTable.getTableName(Env.getCtx(), column.getAD_Table_ID()))))
+			return false;
+
+		return column.isMandatory();
+	}
+
+	/**
+	 * Perform mandatory validation for all columns (either MRestView columns or PO columns) 
+	 * @param po
+	 * @param view
+	 * @param json
+	 * @param event
+	 * @throws IDempiereRestException if there's one or more mandatory columns not filled up with value
+	 */
+	private void validateMandatoryColumns(PO po, MRestView view, JsonObject json, Event event) throws IDempiereRestException {
+		List<String> mandatoryColumns = new ArrayList<>();
+		MTable table = MTable.get(po.getCtx(), po.get_Table_ID());
+		POInfo poInfo = POInfo.getPOInfo(po.getCtx(), po.get_Table_ID());
+		MRestViewColumn[] viewColumns = view != null ? view.getColumns() : null;
+		int count = view != null ? viewColumns.length : poInfo.getColumnCount();
+		Set<String> jsonFields = json.keySet();
+
+		for (int i = 0; i < count; i++) {
+			MRestViewColumn viewColumn = viewColumns != null ? viewColumns[i] : null;
+			String columnName = viewColumn != null ? MColumn.getColumnName(po.getCtx(), viewColumn.getAD_Column_ID()) : poInfo.getColumnName(i);
+			MColumn column = table.getColumn(columnName);
+			String propertyName = null;
+			if (viewColumns != null) {
+				propertyName = viewColumns[i].getName();
+			} else {
+				propertyName = TypeConverterUtils.toPropertyName(columnName);				
+			}
+			//rest view support json path mapping to nested json value object
+			String[] jsonPath = viewColumns != null ? propertyName.split("[.]") : null;
+			if (jsonPath != null && jsonPath.length > 1)
+				propertyName = jsonPath[0];
+
+			if (!po.is_new() && !jsonFields.contains(propertyName) && (viewColumns != null || !jsonFields.contains(columnName)))
+				continue;
+
+			Object value = po.get_ValueOfColumn(column.getAD_Column_ID());
+			if (value == null) {
+				if (viewColumn != null && viewColumn.isMandatory(json)) {
+					mandatoryColumns.add(propertyName);
+				} else if (isMandatory(column, json, column.getMandatoryLogic())) {
+					mandatoryColumns.add(propertyName);
+				}
+			}
+		}
+
+		if (!mandatoryColumns.isEmpty()) {
+			StringBuilder error = new StringBuilder();
+			for (String mandatoryColumn : mandatoryColumns) {
+				error.append(mandatoryColumn).append(", ");
+			}
+			error.delete(error.length() - 2, error.length());
+			IDempiereRestException ex = new IDempiereRestException(Msg.getMsg(po.getCtx(), "ValidationError"),
+					Msg.getMsg(po.getCtx(), "FillMandatory") + error.toString(), Status.BAD_REQUEST);
+			EventHelper.addError(event, ex);
+			throw ex;
+		}
 	}
 	
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -458,14 +458,18 @@ public class ModelResourceImpl implements ModelResource {
 
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, true);
 			try {
-				po.validForeignKeysEx();
+				try {
+					po.validForeignKeysEx();
+				} catch (AdempiereException ex) {
+					throw new IDempiereRestException(Msg.getMsg(po.getCtx(), "ValidationError"), ex.getMessage(), Status.BAD_REQUEST);
+				}
 				String tableFilter = "(tableName="+po.get_TableName()+")";
 				EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);
 				po.saveEx();
 				fireRestSaveEvent(po, PO_AFTER_REST_SAVE, true);
 			} catch (CrossTenantException e) {
 				trx.rollback();
-				return ResponseUtils.getResponseError(Status.INTERNAL_SERVER_ERROR, "Save error", 
+				return ResponseUtils.getResponseError(Status.BAD_REQUEST, Msg.getMsg(po.getCtx(), "ValidationError"), 
 						"Foreign ID " + e.getFKValue() + " not found in ", String.valueOf(e.getFKColumn()));
 			} catch (Exception ex) {
 				trx.rollback();
@@ -679,12 +683,16 @@ public class ModelResourceImpl implements ModelResource {
 			try {
 				String tableFilter = "(tableName="+po.get_TableName()+")";			
 				EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, tableFilter, eventHandler);
-				po.validForeignKeysEx();
+				try {
+					po.validForeignKeysEx();
+				} catch (AdempiereException ex) {
+					throw new IDempiereRestException(Msg.getMsg(po.getCtx(), "ValidationError"), ex.getMessage(), Status.BAD_REQUEST);
+				}
 				po.saveEx();
 				fireRestSaveEvent(po, PO_AFTER_REST_SAVE, false);
 			} catch (CrossTenantException e) {
 				trx.rollback();
-				return ResponseUtils.getResponseError(Status.INTERNAL_SERVER_ERROR, "Save error", 
+				return ResponseUtils.getResponseError(Status.BAD_REQUEST, Msg.getMsg(Env.getCtx(), "ValidationError"), 
 						"Foreign ID " + e.getFKValue() + " not found in ", String.valueOf(e.getFKColumn()));
 			}  catch (Exception ex) {
 				trx.rollback();
@@ -759,7 +767,11 @@ public class ModelResourceImpl implements ModelResource {
 										};
 										
 										fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, false);
-										childPO.validForeignKeysEx();
+										try {
+											childPO.validForeignKeysEx();
+										} catch (AdempiereException ex) {
+											throw new IDempiereRestException(Msg.getMsg(Env.getCtx(), "ValidationError"), ex.getMessage(), Status.BAD_REQUEST);
+										}
 										try {
 											String childTableFilter = "(tableName="+childPO.get_TableName()+")";
 											if (childPO.is_new())
@@ -782,7 +794,7 @@ public class ModelResourceImpl implements ModelResource {
 							trx.rollback();
 							
 							if (ex instanceof CrossTenantException) 
-								return ResponseUtils.getResponseError(Status.INTERNAL_SERVER_ERROR, "Save Error", 
+								return ResponseUtils.getResponseError(Status.BAD_REQUEST, Msg.getMsg(Env.getCtx(), "ValidationError"), 
 										"Foreign ID " + ((CrossTenantException)ex).getFKValue() + " not found in ", String.valueOf(((CrossTenantException)ex).getFKColumn()));
 
 							return ResponseUtils.getResponseErrorFromException(ex, "Save error");

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -459,7 +459,7 @@ public class ModelResourceImpl implements ModelResource {
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, true);
 			try {
 				po.validForeignKeysEx();
-				String tableFilter = "(tableName="+tableName+")";
+				String tableFilter = "(tableName="+po.get_TableName()+")";
 				EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);
 				po.saveEx();
 				fireRestSaveEvent(po, PO_AFTER_REST_SAVE, true);
@@ -584,7 +584,7 @@ public class ModelResourceImpl implements ModelResource {
 							
 							childPO.validForeignKeysEx();
 							try {
-								String tableFilter = "(tableName="+childTable.getTableName()+")";
+								String tableFilter = "(tableName="+childPO.get_TableName()+")";
 								EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);							
 								childPO.saveEx();
 							} finally {
@@ -677,7 +677,7 @@ public class ModelResourceImpl implements ModelResource {
 			
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, false);
 			try {
-				String tableFilter = "(tableName="+tableName+")";			
+				String tableFilter = "(tableName="+po.get_TableName()+")";			
 				EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, tableFilter, eventHandler);
 				po.validForeignKeysEx();
 				po.saveEx();
@@ -761,7 +761,7 @@ public class ModelResourceImpl implements ModelResource {
 										fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, false);
 										childPO.validForeignKeysEx();
 										try {
-											String childTableFilter = "(tableName="+childTable.getTableName()+")";
+											String childTableFilter = "(tableName="+childPO.get_TableName()+")";
 											if (childPO.is_new())
 												EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, childTableFilter, childEventHandler);
 											else

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -573,7 +573,7 @@ public class ModelResourceImpl implements ModelResource {
 							
 							fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, true);
 
-							// Register handler for mandatory fields validation
+							// Event handler for mandatory fields validation
 							JsonObject finalChildJsonObject = childJsonObject;
 							EventHandler eventHandler = (Event evt) ->{
 								PO eventPO = EventHelper.getPO(evt);
@@ -581,11 +581,11 @@ public class ModelResourceImpl implements ModelResource {
 									validateMandatoryColumns(childPO, finalChildView, finalChildJsonObject, evt);
 								}
 							};
-							String tableFilter = "(tableName="+childTable.getTableName()+")";
-							EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);
 							
 							childPO.validForeignKeysEx();
 							try {
+								String tableFilter = "(tableName="+childTable.getTableName()+")";
+								EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, tableFilter, eventHandler);							
 								childPO.saveEx();
 							} finally {
 								EventManager.getInstance().unregister(eventHandler);
@@ -664,7 +664,7 @@ public class ModelResourceImpl implements ModelResource {
 			po = serializer.fromJson(jsonObject, po, view);			
 			po.set_TrxName(trx.getTrxName());
 
-			// Register handler for mandatory fields validation
+			// Event handler for mandatory fields validation
 			PO finalPO = po;
 			MRestView finalView = view;
 			JsonObject finalJsonObject = jsonObject;
@@ -674,11 +674,11 @@ public class ModelResourceImpl implements ModelResource {
 					validateMandatoryColumns(finalPO, finalView, finalJsonObject, evt);
 				}
 			};
-			String tableFilter = "(tableName="+tableName+")";
-			EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, tableFilter, eventHandler);
-
+			
 			fireRestSaveEvent(po, PO_BEFORE_REST_SAVE, false);
 			try {
+				String tableFilter = "(tableName="+tableName+")";			
+				EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, tableFilter, eventHandler);
 				po.validForeignKeysEx();
 				po.saveEx();
 				fireRestSaveEvent(po, PO_AFTER_REST_SAVE, false);
@@ -748,7 +748,7 @@ public class ModelResourceImpl implements ModelResource {
 									if (delete) {
 										childPO.deleteEx(true);
 									} else {
-										// Register event handler for mandatory validation
+										// Event handler for mandatory validation
 										PO finalChilPo = childPO;
 										JsonObject finalChildJsonObject = childJsonObject;
 										EventHandler childEventHandler = (Event evt) ->{
@@ -757,15 +757,15 @@ public class ModelResourceImpl implements ModelResource {
 												validateMandatoryColumns(finalChilPo, finalChildView, finalChildJsonObject, evt);
 											}
 										};
-										String childTableFilter = "(tableName="+childTable.getTableName()+")";
-										if (childPO.is_new())
-											EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, childTableFilter, childEventHandler);
-										else
-											EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, childTableFilter, childEventHandler);
-
+										
 										fireRestSaveEvent(childPO, PO_BEFORE_REST_SAVE, false);
 										childPO.validForeignKeysEx();
 										try {
+											String childTableFilter = "(tableName="+childTable.getTableName()+")";
+											if (childPO.is_new())
+												EventManager.getInstance().register(IEventTopics.PO_BEFORE_NEW, childTableFilter, childEventHandler);
+											else
+												EventManager.getInstance().register(IEventTopics.PO_BEFORE_CHANGE, childTableFilter, childEventHandler);
 											childPO.saveEx();
 										} finally {
 											EventManager.getInstance().unregister(childEventHandler);
@@ -1468,8 +1468,10 @@ public class ModelResourceImpl implements ModelResource {
 
 			Object value = po.get_ValueOfColumn(column.getAD_Column_ID());
 			if (value == null) {
-				if (viewColumn != null && viewColumn.isMandatory(json)) {
-					mandatoryColumns.add(propertyName);
+				if (viewColumn != null) {
+					if (viewColumn.isMandatory(json)) {
+						mandatoryColumns.add(propertyName);
+					}
 				} else if (isMandatory(column, json, column.getMandatoryLogic())) {
 					mandatoryColumns.add(propertyName);
 				}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -1389,7 +1389,9 @@ public class ModelResourceImpl implements ModelResource {
 					@Override
 					public Object getValue(String columnName) {
 						JsonElement element = jsonObject.get(columnName);
-						return element == null ? null : element.getAsString();
+						if (element == null || element.isJsonNull() || !element.isJsonPrimitive())
+							return null;
+						return element.getAsString();
 					}
 	
 					@Override


### PR DESCRIPTION
Test case:
- Create record with mandatory field missing or set to null
- Update record with mandatory field set to null


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent "Bad Request" responses for invalid JSON, with sanitized error messages.
  * Mandatory fields enforced on create/update, including nested JSON paths and view-mapped properties.
  * Attempts to modify read-only/non-updatable columns are rejected with explicit errors.
  * Missing required properties now trigger immediate default-value handling; virtual columns are excluded.

* **Refactor**
  * Centralized mandatory-field validation used across REST create/update flows.

* **New Features**
  * Auth context now records authenticated user name and sales-rep ID for request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->