### PR TITLE
feat(models): add archive read endpoints (#507)

### DIFF
--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -464,6 +464,39 @@ components:
                 description: attachment content type
                 example: image/png
       description: An array of attachment entries
+    Archives:
+      type: object
+      properties:
+        archives:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: AD_Archive_ID of the archive entry
+                example: 1000123
+              name:
+                type: string
+                description: archive name
+                example: Invoice_1000045.pdf
+              contentType:
+                type: string
+                description: archive content type
+                example: application/pdf
+              isReport:
+                type: boolean
+                description: true when the archive was produced by a report/print
+                example: true
+              processId:
+                type: integer
+                description: AD_Process_ID that generated the archive (omitted when not set)
+                example: 110
+              created:
+                type: string
+                description: timestamp the archive was created
+                example: '2026-06-19 09:00:00.0'
+      description: An array of archive entries, most recent first
     TabField:
       description: tab field description
       type: object
@@ -4595,6 +4628,115 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /models/{tableName}/{id}/archives:
+    parameters:
+      - $ref: '#/components/parameters/locale'
+    get:
+      tags:
+        - Models
+      summary: Get list of archives of a record
+      description: >-
+        Returns the archive entries (e.g. previously printed report PDFs stored in
+        AD_Archive) attached to the record, most recent first.
+      parameters:
+        - name: tableName
+          in: path
+          schema:
+            type: string
+          description: table name
+          required: true
+          examples:
+            C_Invoice:
+              value: 'c_invoice'
+        - name: id
+          in: path
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+          description: integer record id or string record uuid
+          required: true
+          examples:
+            C_Invoice_1000045:
+              value: 1000045
+      responses:
+        '200':
+          description: OK. Return the list of archive records.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Archives'
+        '403':
+          $ref: '#/components/responses/ForbiddenGetRecordRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /models/{tableName}/{id}/archives/{archiveId}:
+    parameters:
+      - $ref: '#/components/parameters/locale'
+    get:
+      tags:
+        - Models
+      summary: Get archive of a record by archive id
+      description: >-
+        Returns the binary content of a single archive entry. By default the raw
+        file stream is returned; pass the json query parameter to receive a JSON
+        object with base64 encoded data instead.
+      parameters:
+        - name: tableName
+          in: path
+          schema:
+            type: string
+          description: table name
+          required: true
+        - name: id
+          in: path
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+          description: integer record id or string record uuid
+          required: true
+        - name: archiveId
+          in: path
+          schema:
+            type: integer
+          description: AD_Archive_ID of the archive entry
+          required: true
+        - name: json
+          in: query
+          schema:
+            type: string
+          description: 'not empty to get archive content as base64 encoded data ("data": "base64 content")'
+      responses:
+        '200':
+          description: OK. Successfully retrieved the archive. The response body is either the file stream or a JSON object with base64 encoded data (if json is specified).
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: archive name
+                  contentType:
+                    type: string
+                    description: archive content type
+                  data:
+                    type: string
+                    format: byte
+                    description: base64 encoded archive content
+        '403':
+          $ref: '#/components/responses/ForbiddenGetRecordRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /models/{tableName}/{id}/print:
     parameters:
       - $ref: '#/components/parameters/locale'
@@ -7601,6 +7743,109 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/BinaryResponse'
+        '403':
+          $ref: '#/components/responses/ForbiddenGetRecordRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /views/{viewName}/{id}/archives:
+    parameters:
+      - $ref: '#/components/parameters/locale'
+    get:
+      tags:
+        - Views
+      summary: Get list of archives of a record
+      description: >-
+        Returns the archive entries (e.g. previously printed report PDFs stored in
+        AD_Archive) attached to the record, most recent first.
+      parameters:
+        - name: viewName
+          in: path
+          schema:
+            type: string
+          description: REST_View name
+          required: true
+        - name: id
+          in: path
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+          description: integer record id or string record uuid
+          required: true
+      responses:
+        '200':
+          description: OK. Return the list of archive records.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Archives'
+        '403':
+          $ref: '#/components/responses/ForbiddenGetRecordRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /views/{viewName}/{id}/archives/{archiveId}:
+    parameters:
+      - $ref: '#/components/parameters/locale'
+    get:
+      tags:
+        - Views
+      summary: Get archive of a record by archive id
+      description: >-
+        Returns the binary content of a single archive entry. By default the raw
+        file stream is returned; pass the json query parameter to receive a JSON
+        object with base64 encoded data instead.
+      parameters:
+        - name: viewName
+          in: path
+          schema:
+            type: string
+          description: REST_View name
+          required: true
+        - name: id
+          in: path
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+          description: integer record id or string record uuid
+          required: true
+        - name: archiveId
+          in: path
+          schema:
+            type: integer
+          description: AD_Archive_ID of the archive entry
+          required: true
+        - name: json
+          in: query
+          schema:
+            type: string
+          description: 'not empty to get archive content as base64 encoded data ("data": "base64 content")'
+      responses:
+        '200':
+          description: OK. Successfully retrieved the archive. The response body is either the file stream or a JSON object with base64 encoded data (if json is specified).
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: archive name
+                  contentType:
+                    type: string
+                    description: archive content type
+                  data:
+                    type: string
+                    format: byte
+                    description: base64 encoded archive content
         '403':
           $ref: '#/components/responses/ForbiddenGetRecordRequest'
         '404':

--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4721,12 +4721,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  name:
-                    type: string
-                    description: archive name
-                  contentType:
-                    type: string
-                    description: archive content type
                   data:
                     type: string
                     format: byte
@@ -7836,12 +7830,6 @@ paths:
               schema:
                 type: object
                 properties:
-                  name:
-                    type: string
-                    description: archive name
-                  contentType:
-                    type: string
-                    description: archive content type
                   data:
                     type: string
                     format: byte

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -2731,6 +2731,137 @@
 			"response": []
 		},
 		{
+			"name": "api/v1/models/{table name}/{id}/archives",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_invoice/1000045/archives",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_invoice",
+						"1000045",
+						"archives"
+					]
+				},
+				"description": "Get the list of archives (e.g. previously printed report PDFs) of a record, most recent first"
+			},
+			"response": []
+		},
+		{
+			"name": "api/v1/models/{table name}/{id}/archives/{archive id}",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/octet-stream",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_invoice/1000045/archives/1000123",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_invoice",
+						"1000045",
+						"archives",
+						"1000123"
+					]
+				},
+				"description": "Get the binary content of a single archive entry by AD_Archive_ID"
+			},
+			"response": []
+		},
+		{
+			"name": "api/v1/models/{table name}/{id}/archives/{archive id}?json",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_invoice/1000045/archives/1000123?json=true",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_invoice",
+						"1000045",
+						"archives",
+						"1000123"
+					],
+					"query": [
+						{
+							"key": "json",
+							"value": "true"
+						}
+					]
+				},
+				"description": "Get a single archive entry as base64 encoded JSON (json query param)"
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/models/{table name}/{id}/attachments",
 			"request": {
 				"method": "POST",

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
@@ -245,7 +245,7 @@ public interface ModelResource {
 
 	@Path("{tableName}/{id}/archives/{archiveId}")
 	@GET
-	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	@Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
 	/**
 	 * Get content of an archive item
 	 * @param tableName

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
@@ -231,7 +231,30 @@ public interface ModelResource {
 	 * @return http response
 	 */
 	public Response deleteAttachmentEntry(@PathParam("tableName") String tableName, @PathParam("id") String id, @PathParam("fileName") String fileName);
-	
+
+	@Path("{tableName}/{id}/archives")
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	/**
+	 * Get archives (e.g. previously printed report PDFs) of a record, most recent first
+	 * @param tableName
+	 * @param id record id/uuid
+	 * @return json array of archive item
+	 */
+	public Response getArchives(@PathParam("tableName") String tableName, @PathParam("id") String id);
+
+	@Path("{tableName}/{id}/archives/{archiveId}")
+	@GET
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	/**
+	 * Get content of an archive item
+	 * @param tableName
+	 * @param id record id/uuid
+	 * @param archiveId AD_Archive_ID of an archive item
+	 * @return binary stream of an archive item
+	 */
+	public Response getArchiveEntry(@PathParam("tableName") String tableName, @PathParam("id") String id, @PathParam("archiveId") int archiveId, @QueryParam(QueryOperators.AS_JSON) String asJson);
+
 	@Path("{tableName}/{id}/print")
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -992,7 +992,7 @@ public class ModelResourceImpl implements ModelResource {
 					} else {
 						JsonObject json = new JsonObject();
 						json.addProperty("data", Base64.getEncoder().encodeToString(binaryData));
-						return Response.ok(json.toString()).build();
+						return Response.ok(json.toString(), "application/json").build();
 					}
 				}
 			}
@@ -1017,7 +1017,7 @@ public class ModelResourceImpl implements ModelResource {
 	private String getArchiveContentType(MArchive archive) {
 		String mimeType = Util.isEmpty(archive.getName(), true) ? null : MimeType.getMimeType(archive.getName());
 		if (Util.isEmpty(mimeType, true) || "application/octet-stream".equals(mimeType))
-			return "application/pdf";
+			return archive.isReport() ? "application/pdf" : "application/octet-stream";
 		return mimeType;
 	}
 

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -57,6 +57,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.CrossTenantException;
 import org.compiere.model.GridField;
 import org.compiere.model.GridFieldVO;
+import org.compiere.model.MArchive;
 import org.compiere.model.MAttachment;
 import org.compiere.model.MAttachmentEntry;
 import org.compiere.model.MColumn;
@@ -924,6 +925,100 @@ public class ModelResourceImpl implements ModelResource {
 		} else {
 			return poParser.getResponseError();
 		}
+	}
+
+	@Override
+	public Response getArchives(String tableName, String id) {
+		MRestView view = null;
+		if (useRestView) {
+			view = RestUtils.getView(tableName);
+			if (view != null)
+				tableName = MTable.getTableName(Env.getCtx(), view.getAD_Table_ID());
+			else
+				return ResponseUtils.getResponseErrorFromException(new IDempiereRestException("Invalid rest view name", "No match found for rest view name: " + tableName, Status.NOT_FOUND), "Not found");
+		}
+
+		JsonArray array = new JsonArray();
+		POParser poParser = new POParser(tableName, id, true, false);
+		if (poParser.isValidPO()) {
+			PO po = poParser.getPO();
+			List<MArchive> archives = new Query(Env.getCtx(), MArchive.Table_Name, "AD_Table_ID=? AND Record_ID=?", null)
+					.setParameters(po.get_Table_ID(), po.get_ID())
+					.setOrderBy("Created DESC")
+					.list();
+			for (MArchive archive : archives) {
+				JsonObject entryJsonObject = new JsonObject();
+				entryJsonObject.addProperty("id", archive.getAD_Archive_ID());
+				if (!Util.isEmpty(archive.getName(), true))
+					entryJsonObject.addProperty("name", archive.getName());
+				entryJsonObject.addProperty("contentType", getArchiveContentType(archive));
+				entryJsonObject.addProperty("isReport", archive.isReport());
+				if (archive.getAD_Process_ID() > 0)
+					entryJsonObject.addProperty("processId", archive.getAD_Process_ID());
+				if (archive.getCreated() != null)
+					entryJsonObject.addProperty("created", archive.getCreated().toString());
+				array.add(entryJsonObject);
+			}
+			JsonObject json = new JsonObject();
+			json.add("archives", array);
+			return Response.ok(json.toString()).build();
+		} else {
+			return poParser.getResponseError();
+		}
+	}
+
+	@Override
+	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson) {
+		MRestView view = null;
+		if (useRestView) {
+			view = RestUtils.getView(tableName);
+			if (view != null)
+				tableName = MTable.getTableName(Env.getCtx(), view.getAD_Table_ID());
+			else
+				return ResponseUtils.getResponseErrorFromException(new IDempiereRestException("Invalid rest view name", "No match found for rest view name: " + tableName, Status.NOT_FOUND), "Not found");
+		}
+
+		POParser poParser = new POParser(tableName, id, true, false);
+		if (poParser.isValidPO()) {
+			PO po = poParser.getPO();
+			MArchive archive = new Query(Env.getCtx(), MArchive.Table_Name, "AD_Archive_ID=? AND AD_Table_ID=? AND Record_ID=?", null)
+					.setParameters(archiveId, po.get_Table_ID(), po.get_ID())
+					.first();
+			if (archive != null) {
+				byte[] binaryData = archive.getBinaryData();
+				if (binaryData != null) {
+					if (asJson == null) {
+						return Response.ok(binaryData).header("Content-Type", getArchiveContentType(archive)).build();
+					} else {
+						JsonObject json = new JsonObject();
+						json.addProperty("data", Base64.getEncoder().encodeToString(binaryData));
+						return Response.ok(json.toString()).build();
+					}
+				}
+			}
+			return Response.status(Status.NOT_FOUND)
+					.entity(new ErrorBuilder().status(Status.NOT_FOUND)
+							.title("No archive entry found")
+							.append("No archive entry found for id: ")
+							.append(String.valueOf(archiveId))
+							.build().toString())
+					.build();
+		} else {
+			return poParser.getResponseError();
+		}
+	}
+
+	/**
+	 * Resolve the content type of an archive. Archives are normally report PDFs,
+	 * so fall back to application/pdf when the name carries no usable extension.
+	 * @param archive archive item
+	 * @return mime type
+	 */
+	private String getArchiveContentType(MArchive archive) {
+		String mimeType = Util.isEmpty(archive.getName(), true) ? null : MimeType.getMimeType(archive.getName());
+		if (Util.isEmpty(mimeType, true) || "application/octet-stream".equals(mimeType))
+			return "application/pdf";
+		return mimeType;
 	}
 
 	@Override

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ViewResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ViewResourceImpl.java
@@ -227,6 +227,16 @@ public class ViewResourceImpl implements ViewResource {
 	}
 
 	@Override
+	public Response getArchives(String tableName, String id) {
+		return restView().getArchives(tableName, id);
+	}
+
+	@Override
+	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson) {
+		return restView().getArchiveEntry(tableName, id, archiveId, asJson);
+	}
+
+	@Override
 	public Response printModelRecord(String tableName, String id, String reportType) {
 		return restView().printModelRecord(tableName, id, reportType);
 	}


### PR DESCRIPTION
Add two read-only endpoints to fetch a record's archived documents (e.g. previously printed invoice PDFs in AD_Archive), modeled 1:1 on the existing attachments endpoints:

  GET /models/{tableName}/{id}/archives              list, newest first
  GET /models/{tableName}/{id}/archives/{archiveId}  binary (?json -> base64)

Lookup is MArchive by AD_Table_ID + Record_ID ordered Created DESC, so the latest archive is first. Access inherits the record via POParser, and binary is served through the configured archive-store provider (MArchive.getBinaryData), so filesystem/DB/S3 backends work transparently. print stays the producer; these endpoints are pure read.

ViewResourceImpl gets matching delegating overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST endpoints to list archived/previously printed report artifacts for a specific record (Models and Views), returning metadata such as id, optional name, content type, report/process indicators, and creation time (most recent first).
  * Added REST endpoints to retrieve an individual archive entry as either direct binary download (with correct content type) or JSON containing base64-encoded content via a `json` query parameter.
* **Documentation**
  * Updated OpenAPI and Postman collection with the new archive endpoints and response schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->