### PR TITLE
feat(models): presigned (iDempiere-signed) download link for record archives

### DIFF
--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4723,6 +4723,7 @@ paths:
           schema:
             type: integer
             default: 0
+            minimum: 0
           description: 'lifetime of the presigned URL in seconds (0 = use server default; capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS)'
       responses:
         '200':
@@ -7855,6 +7856,7 @@ paths:
           schema:
             type: integer
             default: 0
+            minimum: 0
           description: 'lifetime of the presigned URL in seconds (0 = use server default; capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS)'
       responses:
         '200':

--- a/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
+++ b/com.trekglobal.idempiere.rest.api/openapi/idempiere-rest.yml
@@ -4682,7 +4682,10 @@ paths:
       description: >-
         Returns the binary content of a single archive entry. By default the raw
         file stream is returned; pass the json query parameter to receive a JSON
-        object with base64 encoded data instead.
+        object with base64 encoded data instead. Pass presign=true to receive a
+        time-limited signed URL ({"url": "..."}) that can be shared without
+        authentication. The expiry is capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS
+        (default 3600s).
       parameters:
         - name: tableName
           in: path
@@ -4709,9 +4712,23 @@ paths:
           schema:
             type: string
           description: 'not empty to get archive content as base64 encoded data ("data": "base64 content")'
+        - name: presign
+          in: query
+          schema:
+            type: string
+            enum: ['true']
+          description: 'pass "true" to return a presigned URL instead of binary content'
+        - name: expiresInSeconds
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: 'lifetime of the presigned URL in seconds (0 = use server default; capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS)'
       responses:
         '200':
-          description: OK. Successfully retrieved the archive. The response body is either the file stream or a JSON object with base64 encoded data (if json is specified).
+          description: >-
+            OK. Response is the file stream, a JSON object with base64 encoded data
+            (if json is specified), or a JSON object with a presigned URL (if presign=true).
           content:
             application/octet-stream:
               schema:
@@ -4719,12 +4736,18 @@ paths:
                 format: binary
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: string
-                    format: byte
-                    description: base64 encoded archive content
+                oneOf:
+                  - type: object
+                    properties:
+                      data:
+                        type: string
+                        format: byte
+                        description: base64 encoded archive content
+                  - type: object
+                    properties:
+                      url:
+                        type: string
+                        description: presigned URL for direct download without authentication
         '403':
           $ref: '#/components/responses/ForbiddenGetRecordRequest'
         '404':
@@ -7791,7 +7814,10 @@ paths:
       description: >-
         Returns the binary content of a single archive entry. By default the raw
         file stream is returned; pass the json query parameter to receive a JSON
-        object with base64 encoded data instead.
+        object with base64 encoded data instead. Pass presign=true to receive a
+        time-limited signed URL ({"url": "..."}) that can be shared without
+        authentication. The expiry is capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS
+        (default 3600s).
       parameters:
         - name: viewName
           in: path
@@ -7818,9 +7844,23 @@ paths:
           schema:
             type: string
           description: 'not empty to get archive content as base64 encoded data ("data": "base64 content")'
+        - name: presign
+          in: query
+          schema:
+            type: string
+            enum: ['true']
+          description: 'pass "true" to return a presigned URL instead of binary content'
+        - name: expiresInSeconds
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: 'lifetime of the presigned URL in seconds (0 = use server default; capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS)'
       responses:
         '200':
-          description: OK. Successfully retrieved the archive. The response body is either the file stream or a JSON object with base64 encoded data (if json is specified).
+          description: >-
+            OK. Response is the file stream, a JSON object with base64 encoded data
+            (if json is specified), or a JSON object with a presigned URL (if presign=true).
           content:
             application/octet-stream:
               schema:
@@ -7828,12 +7868,18 @@ paths:
                 format: binary
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: string
-                    format: byte
-                    description: base64 encoded archive content
+                oneOf:
+                  - type: object
+                    properties:
+                      data:
+                        type: string
+                        format: byte
+                        description: base64 encoded archive content
+                  - type: object
+                    properties:
+                      url:
+                        type: string
+                        description: presigned URL for direct download without authentication
         '403':
           $ref: '#/components/responses/ForbiddenGetRecordRequest'
         '404':

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -2862,6 +2862,58 @@
 			"response": []
 		},
 		{
+			"name": "api/v1/models/{table name}/{id}/archives/{archive id}?presign",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_invoice/1000045/archives/1000123?presign=true&expiresInSeconds=600",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_invoice",
+						"1000045",
+						"archives",
+						"1000123"
+					],
+					"query": [
+						{
+							"key": "presign",
+							"value": "true"
+						},
+						{
+							"key": "expiresInSeconds",
+							"value": "600"
+						}
+					]
+				},
+				"description": "Get a presigned (time-limited, auth-free) download URL for a single archive entry. Returns {\"url\": \"...\"}"
+			},
+			"response": []
+		},
+		{
 			"name": "api/v1/models/{table name}/{id}/attachments",
 			"request": {
 				"method": "POST",
@@ -5793,104 +5845,104 @@
 			"response": []
 		},
 		{
-		  "name": "api/v1/models/{table name} - timestamp eq filter",
-		  "request": {
-			"method": "GET",
-			"header": [
-			  {
-				"key": "Content-Type",
-				"value": "application/json",
-				"type": "text"
-			  },
-			  {
-				"key": "Accept",
-				"value": "application/json",
-				"type": "text"
-			  },
-			  {
-				"key": "Authorization",
-				"value": "Bearer {{authToken}}",
-				"type": "text"
-			  }
-			],
-			"url": {
-			  "raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created eq '2003-01-08T15:06:11'&$select=name,created",
-			  "protocol": "{{protocol}}",
-			  "host": [
-				"{{host}}"
-			  ],
-			  "port": "{{port}}",
-			  "path": [
-				"api",
-				"v1",
-				"models",
-				"c_tax"
-			  ],
-			  "query": [
-				{
-				  "key": "$filter",
-				  "value": "created eq '2003-01-08T15:06:11'"
+			"name": "api/v1/models/{table name} - timestamp eq filter",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created eq '2003-01-08T15:06:11'&$select=name,created",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_tax"
+					],
+					"query": [
+						{
+							"key": "$filter",
+							"value": "created eq '2003-01-08T15:06:11'"
+						},
+						{
+							"key": "$select",
+							"value": "name,created",
+							"type": "text"
+						}
+					]
 				},
-				{
-				  "key": "$select",
-				  "value": "name,created",
-				  "type": "text"
-				}
-			  ]
+				"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
 			},
-			"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
-		  },
-		  "response": []
+			"response": []
 		},
 		{
-		  "name": "api/v1/models/{table name} - timestamp range filter",
-		  "request": {
-			"method": "GET",
-			"header": [
-			  {
-				"key": "Content-Type",
-				"value": "application/json",
-				"type": "text"
-			  },
-			  {
-				"key": "Accept",
-				"value": "application/json",
-				"type": "text"
-			  },
-			  {
-				"key": "Authorization",
-				"value": "Bearer {{authToken}}",
-				"type": "text"
-			  }
-			],
-			"url": {
-			  "raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'&$select=name,created",
-			  "protocol": "{{protocol}}",
-			  "host": [
-				"{{host}}"
-			  ],
-			  "port": "{{port}}",
-			  "path": [
-				"api",
-				"v1",
-				"models",
-				"c_tax"
-			  ],
-			  "query": [
-				{
-				  "key": "$filter",
-				  "value": "created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'"
+			"name": "api/v1/models/{table name} - timestamp range filter",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{authToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'&$select=name,created",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"api",
+						"v1",
+						"models",
+						"c_tax"
+					],
+					"query": [
+						{
+							"key": "$filter",
+							"value": "created ge '2003-01-08T01:06:11Z' and created lt '2003-01-09T23:20:21Z'"
+						},
+						{
+							"key": "$select",
+							"value": "name,created"
+						}
+					]
 				},
-				{
-				  "key": "$select",
-				  "value": "name,created"
-				}
-			  ]
+				"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
 			},
-			"description": "Get records for table with optional filter, orderBy and pageNo parameter. Default page size is 100."
-		  },
-		  "response": []
-		}		
+			"response": []
+		}
 	],
 	"event": [
 		{

--- a/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
+++ b/com.trekglobal.idempiere.rest.api/postman/trekglobal-idempiere-rest.postman_collection.json
@@ -5866,7 +5866,7 @@
 					}
 				],
 				"url": {
-					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created eq '2003-01-08T15:06:11'&$select=name,created",
+					"raw": "{{protocol}}://{{host}}:{{port}}/api/v1/models/c_tax?$filter=created eq '2003-01-08T15:06:11Z'&$select=name,created",
 					"protocol": "{{protocol}}",
 					"host": [
 						"{{host}}"
@@ -5881,7 +5881,7 @@
 					"query": [
 						{
 							"key": "$filter",
-							"value": "created eq '2003-01-08T15:06:11'"
+							"value": "created eq '2003-01-08T15:06:11Z'"
 						},
 						{
 							"key": "$select",

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/ModelResource.java
@@ -247,13 +247,19 @@ public interface ModelResource {
 	@GET
 	@Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
 	/**
-	 * Get content of an archive item
+	 * Get content of an archive item.
+	 * When presign=true, returns a JSON object with a signed URL instead of streaming bytes.
 	 * @param tableName
 	 * @param id record id/uuid
 	 * @param archiveId AD_Archive_ID of an archive item
-	 * @return binary stream of an archive item
+	 * @param asJson return content as base64-encoded JSON
+	 * @param presign if "true", return a presigned URL instead of binary content
+	 * @param expiresInSeconds lifetime of the presigned URL in seconds (capped by REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS)
+	 * @return binary stream, base64 JSON, or presigned URL JSON
 	 */
-	public Response getArchiveEntry(@PathParam("tableName") String tableName, @PathParam("id") String id, @PathParam("archiveId") int archiveId, @QueryParam(QueryOperators.AS_JSON) String asJson);
+	public Response getArchiveEntry(@PathParam("tableName") String tableName, @PathParam("id") String id,
+			@PathParam("archiveId") int archiveId, @QueryParam(QueryOperators.AS_JSON) String asJson,
+			@QueryParam("presign") String presign, @DefaultValue("0") @QueryParam("expiresInSeconds") long expiresInSeconds);
 
 	@Path("{tableName}/{id}/print")
 	@GET

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -965,7 +965,7 @@ public class ModelResourceImpl implements ModelResource {
 				if (archive.getAD_Process_ID() > 0)
 					entryJsonObject.addProperty("processId", archive.getAD_Process_ID());
 				if (archive.getCreated() != null)
-					entryJsonObject.addProperty("created", archive.getCreated().toString());
+					entryJsonObject.addProperty("created", archive.getCreated().toInstant().toString());
 				array.add(entryJsonObject);
 			}
 			JsonObject json = new JsonObject();
@@ -999,6 +999,12 @@ public class ModelResourceImpl implements ModelResource {
 					int maxExpire = MSysConfig.getIntValue(REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS, 3600);
 					if (expiresInSeconds <= 0 || expiresInSeconds > maxExpire)
 						expiresInSeconds = maxExpire;
+					String nativeUrl = archive.getPresignedURL(expiresInSeconds);
+					if (nativeUrl != null) {
+						JsonObject json = new JsonObject();
+						json.addProperty("url", nativeUrl);
+						return Response.ok(json.toString(), "application/json").build();
+					}
 					String archivePrefix = useRestView ? "v1/views/" : "v1/models/";
 					String archivePath = archivePrefix + originalTableName + "/" + id + "/archives/" + archiveId;
 					String presignedURLParams = PresignedURL.createPresignedURLParams("GET", archivePath, expiresInSeconds);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -44,8 +44,10 @@ import java.util.logging.Level;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
 import javax.xml.bind.DatatypeConverter;
 
 import org.adempiere.base.event.EventHelper;
@@ -75,6 +77,7 @@ import org.compiere.util.DefaultEvaluatee.DataProvider;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluator;
+import org.compiere.model.MSysConfig;
 import org.compiere.util.MimeType;
 import org.compiere.util.Msg;
 import org.compiere.util.Trx;
@@ -104,6 +107,7 @@ import com.trekglobal.idempiere.rest.api.model.MRestViewColumn;
 import com.trekglobal.idempiere.rest.api.model.MRestViewRelated;
 import com.trekglobal.idempiere.rest.api.util.ErrorBuilder;
 import com.trekglobal.idempiere.rest.api.util.ThreadLocalTrx;
+import com.trekglobal.idempiere.rest.api.v1.auth.filter.PresignedURL;
 import com.trekglobal.idempiere.rest.api.v1.resource.ModelResource;
 import com.trekglobal.idempiere.rest.api.v1.resource.WindowResource;
 import com.trekglobal.idempiere.rest.api.v1.resource.file.FileStreamingOutput;
@@ -118,6 +122,11 @@ public class ModelResourceImpl implements ModelResource {
 	
 	public static final String PO_BEFORE_REST_SAVE = "idempiere-rest/po/beforeSave";
 	public static final String PO_AFTER_REST_SAVE = "idempiere-rest/po/afterSave";
+
+	private static final String REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS = "REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS";
+
+	@Context
+	private UriInfo uriInfo;
 
 	private boolean useRestView = false;
 	
@@ -968,7 +977,8 @@ public class ModelResourceImpl implements ModelResource {
 	}
 
 	@Override
-	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson) {
+	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson, String presign, long expiresInSeconds) {
+		String originalTableName = tableName;
 		MRestView view = null;
 		if (useRestView) {
 			view = RestUtils.getView(tableName);
@@ -985,6 +995,18 @@ public class ModelResourceImpl implements ModelResource {
 					.setParameters(archiveId, po.get_Table_ID(), po.get_ID())
 					.first();
 			if (archive != null) {
+				if ("true".equalsIgnoreCase(presign)) {
+					int maxExpire = MSysConfig.getIntValue(REST_PRESIGNED_URL_MAX_EXPIRE_SECONDS, 3600);
+					if (expiresInSeconds <= 0 || expiresInSeconds > maxExpire)
+						expiresInSeconds = maxExpire;
+					String archivePrefix = useRestView ? "v1/views/" : "v1/models/";
+					String archivePath = archivePrefix + originalTableName + "/" + id + "/archives/" + archiveId;
+					String presignedURLParams = PresignedURL.createPresignedURLParams("GET", archivePath, expiresInSeconds);
+					String baseUrl = uriInfo.getBaseUri().toString();
+					JsonObject json = new JsonObject();
+					json.addProperty("url", baseUrl + archivePath + presignedURLParams);
+					return Response.ok(json.toString(), "application/json").build();
+				}
 				byte[] binaryData = archive.getBinaryData();
 				if (binaryData != null) {
 					if (asJson == null) {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ViewResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ViewResourceImpl.java
@@ -232,8 +232,8 @@ public class ViewResourceImpl implements ViewResource {
 	}
 
 	@Override
-	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson) {
-		return restView().getArchiveEntry(tableName, id, archiveId, asJson);
+	public Response getArchiveEntry(String tableName, String id, int archiveId, String asJson, String presign, long expiresInSeconds) {
+		return restView().getArchiveEntry(tableName, id, archiveId, asJson, presign, expiresInSeconds);
 	}
 
 	@Override


### PR DESCRIPTION
issue: https://github.com/bxservice/idempiere-rest/issues/509

prerequisite issue: #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced archive downloads for models and views to optionally return time-limited presigned URLs with `presign=true`.
  * Added `expiresInSeconds` support with server-enforced expiry limits, alongside binary and base64 JSON responses.
* **Documentation**
  * Updated the OpenAPI specification and Postman collection with the new parameters and response formats.
* **Bug Fixes**
  * Standardized archive creation timestamps to RFC 3339 format and refreshed timestamp examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->