### PR TITLE
fix(json): read C_Location/AD_Image within request transaction on ser…

### DIFF
--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/ImageTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/ImageTypeConverterTest.java
@@ -27,7 +27,7 @@ package com.trekglobal.idempiere.rest.api.json.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 import org.compiere.model.MColumn;
@@ -36,6 +36,7 @@ import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockitoAnnotations;
 
 import com.google.gson.JsonObject;
@@ -47,8 +48,6 @@ public class ImageTypeConverterTest extends RestTestCase {
 	
 	@Mock
 	private MColumn mockColumn;
-	@Mock
-    private MImage image;
 
     @BeforeEach
     public void setUp() {
@@ -58,19 +57,19 @@ public class ImageTypeConverterTest extends RestTestCase {
 
     @Test
     public void toJsonValueReturnsJsonObjectForValidImage() {
-        when(image.getBinaryData()).thenReturn(new byte[]{1, 2, 3});
-        when(image.get_ID()).thenReturn(100);
-        when(image.get_TableName()).thenReturn("AD_Image");
         when(mockColumn.getColumnName()).thenReturn("ImageColumn");
-        mockStatic(MImage.class);
-        when(MImage.get(100)).thenReturn(image);
 
-        Object result = converter.toJsonValue(mockColumn, 100);
-        JsonObject json = (JsonObject) result;
+        try (MockedConstruction<MImage> mocked = mockConstruction(MImage.class, (mock, context) -> {
+            when(mock.get_ID()).thenReturn(100);
+            when(mock.getBinaryData()).thenReturn(new byte[]{1, 2, 3});
+        })) {
+            Object result = converter.toJsonValue(mockColumn, 100);
+            JsonObject json = (JsonObject) result;
 
-        assertEquals(100, json.get("id").getAsInt());
-        assertEquals("AQID", json.get("data").getAsString());
-        assertEquals("ad_image", json.get("model-name").getAsString());
+            assertEquals(100, json.get("id").getAsInt());
+            assertEquals("AQID", json.get("data").getAsString());
+            assertEquals("ad_image", json.get("model-name").getAsString());
+        }
     }
 
     @Test
@@ -81,10 +80,12 @@ public class ImageTypeConverterTest extends RestTestCase {
 
     @Test
     public void toJsonValueReturnsNullForInvalidImageId() {
-        when(MImage.get(999)).thenReturn(null);
-
-        Object result = converter.toJsonValue(mockColumn, 999);
-        assertNull(result);
+        try (MockedConstruction<MImage> mocked = mockConstruction(MImage.class, (mock, context) -> {
+            when(mock.get_ID()).thenReturn(0);
+        })) {
+            Object result = converter.toJsonValue(mockColumn, 999);
+            assertNull(result);
+        }
     }
 
     @Test

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/LocationTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/LocationTypeConverterTest.java
@@ -29,8 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
 import org.adempiere.exceptions.AdempiereException;
@@ -41,7 +40,7 @@ import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
+import org.mockito.MockedConstruction;
 import org.mockito.MockitoAnnotations;
 
 import com.google.gson.JsonObject;
@@ -66,13 +65,11 @@ public class LocationTypeConverterTest extends RestTestCase {
 		when(mockColumn.getColumnName()).thenReturn("C_Location_ID");
 		when(mockColumn.getReferenceTableName()).thenReturn("C_Location");
 
-		MLocation mockLocation = mock(MLocation.class);
-		try (MockedStatic<MLocation> mocked = mockStatic(MLocation.class)) {
-			mocked.when(() -> MLocation.get(123456)).thenReturn(mockLocation);
-			when(mockLocation.get_ID()).thenReturn(123456);
-			when(mockLocation.get_Value("City")).thenReturn("New York");
-			when(mockLocation.get_Value("C_Region_ID")).thenReturn(200);
-
+		try (MockedConstruction<MLocation> mocked = mockConstruction(MLocation.class, (mock, context) -> {
+			when(mock.get_ID()).thenReturn(123456);
+			when(mock.get_Value("City")).thenReturn("New York");
+			when(mock.get_Value("C_Region_ID")).thenReturn(200);
+		})) {
 			Object result = converter.toJsonValue(mockColumn, 123456, null);
 			JsonObject json = (JsonObject) result;
 
@@ -89,14 +86,33 @@ public class LocationTypeConverterTest extends RestTestCase {
 		when(mockColumn.getColumnName()).thenReturn("C_Location_ID");
 		when(mockColumn.getReferenceTableName()).thenReturn("C_Location");
 
-		MLocation mockLocation = mock(MLocation.class);
-		try (MockedStatic<MLocation> mocked = mockStatic(MLocation.class)) {
-			mocked.when(() -> MLocation.get(123456)).thenReturn(mockLocation);
-			when(mockLocation.get_ID()).thenReturn(123456);
+		try (MockedConstruction<MLocation> mocked = mockConstruction(MLocation.class, (mock, context) -> {
+			when(mock.get_ID()).thenReturn(123456);
 			//invalid columns
-			when(mockLocation.get_Value("Cities")).thenReturn("New York");
-			when(mockLocation.get_Value("Region_ID")).thenReturn(200); 
+			when(mock.get_Value("Cities")).thenReturn("New York");
+			when(mock.get_Value("Region_ID")).thenReturn(200);
+		})) {
+			Object result = converter.toJsonValue(mockColumn, 123456, null);
+			JsonObject json = (JsonObject) result;
 
+			assertEquals(123456, json.get("id").getAsInt());
+			assertNull(json.get("City"));
+			assertNull(json.get("C_Region_ID"));
+			assertEquals("c_location", json.get("model-name").getAsString());
+		}
+	}
+
+	@Test
+	public void toJsonValueSkipsDerivedFieldsForInvalidLocationId() {
+		when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.Location);
+		when(mockColumn.getColumnName()).thenReturn("C_Location_ID");
+		when(mockColumn.getReferenceTableName()).thenReturn("C_Location");
+
+		try (MockedConstruction<MLocation> mocked = mockConstruction(MLocation.class, (mock, context) -> {
+			when(mock.get_ID()).thenReturn(0);
+			when(mock.get_Value("City")).thenReturn("New York");
+			when(mock.get_Value("C_Region_ID")).thenReturn(200);
+		})) {
 			Object result = converter.toJsonValue(mockColumn, 123456, null);
 			JsonObject json = (JsonObject) result;
 

--- a/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/LookupTypeConverterTest.java
+++ b/com.trekglobal.idempiere.rest.api.test/src/com/trekglobal/idempiere/rest/api/json/test/LookupTypeConverterTest.java
@@ -27,12 +27,17 @@ package com.trekglobal.idempiere.rest.api.json.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.GridField;
+import org.compiere.model.GridFieldVO;
 import org.compiere.model.Lookup;
 import org.compiere.model.MColumn;
+import org.compiere.model.MLookup;
 import org.compiere.util.DisplayType;
+import org.compiere.util.KeyNamePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -91,6 +96,43 @@ public class LookupTypeConverterTest extends RestTestCase {
 	    when(mockColumn.getAD_Reference_ID()).thenReturn(DisplayType.Table);
 
 	    assertThrows(AdempiereException.class, () -> converter.fromJsonValue(mockColumn, json));
+	}
+
+	@Test
+	public void toJsonValueResolvesIdentifierWithinTransaction() {
+		GridField field = mock(GridField.class);
+		GridFieldVO vo = mock(GridFieldVO.class);
+		MLookup mlookup = mock(MLookup.class);
+		when(field.getVO()).thenReturn(vo);
+		when(field.getAD_Column_ID()).thenReturn(0);
+		when(field.getDisplayType()).thenReturn(DisplayType.TableDir);
+		when(field.getHeader()).thenReturn("C_BPartner_ID");
+		when(field.getLookup()).thenReturn(mlookup);
+		when(mlookup.getDirect(200000, false, false, "junit-lookup"))
+			.thenReturn(new KeyNamePair(200000, "Agri-Tech"));
+
+		JsonObject json = (JsonObject) converter.toJsonValue(field, 200000, "junit-lookup");
+
+		assertEquals(200000, json.get("id").getAsInt());
+		assertEquals("Agri-Tech", json.get("identifier").getAsString());
+	}
+
+	@Test
+	public void toJsonValueFallsBackToGetDisplayWithoutTransaction() {
+		GridField field = mock(GridField.class);
+		GridFieldVO vo = mock(GridFieldVO.class);
+		MLookup mlookup = mock(MLookup.class);
+		when(field.getVO()).thenReturn(vo);
+		when(field.getAD_Column_ID()).thenReturn(0);
+		when(field.getDisplayType()).thenReturn(DisplayType.TableDir);
+		when(field.getHeader()).thenReturn("C_BPartner_ID");
+		when(field.getLookup()).thenReturn(mlookup);
+		when(mlookup.getDisplay(200000)).thenReturn("Agri-Tech");
+
+		JsonObject json = (JsonObject) converter.toJsonValue(field, 200000);
+
+		assertEquals(200000, json.get("id").getAsInt());
+		assertEquals("Agri-Tech", json.get("identifier").getAsString());
 	}
 
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultGridTabSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultGridTabSerializer.java
@@ -56,6 +56,11 @@ public class DefaultGridTabSerializer implements IGridTabSerializer, IGridTabSer
 
 	@Override
 	public JsonObject toJson(GridTab gridTab, String[] includes, String[] excludes) {
+		return toJson(gridTab, includes, excludes, null);
+	}
+
+	@Override
+	public JsonObject toJson(GridTab gridTab, String[] includes, String[] excludes, String trxName) {
 		JsonObject json = new JsonObject();
 		String keyColumn = gridTab.getKeyColumnName();
 		if (!Util.isEmpty(keyColumn, true)) {
@@ -98,7 +103,7 @@ public class DefaultGridTabSerializer implements IGridTabSerializer, IGridTabSer
 				continue;
 			
 			String propertyName = column.getColumnName();
-			Object jsonValue = TypeConverterUtils.toJsonValue(gridField, value);
+			Object jsonValue = TypeConverterUtils.toJsonValue(gridField, value, trxName);
 			if (jsonValue != null) {
 				if (jsonValue instanceof Number)
 					json.addProperty(propertyName, (Number)jsonValue);
@@ -118,6 +123,11 @@ public class DefaultGridTabSerializer implements IGridTabSerializer, IGridTabSer
 	
 	@Override
 	public void fromJson(JsonObject json, GridTab gridTab) {
+		fromJson(json, gridTab, null);
+	}
+
+	@Override
+	public void fromJson(JsonObject json, GridTab gridTab, String trxName) {
 		Set<String> jsonFields = json.keySet();
 		for(int i = 0; i < gridTab.getFieldCount(); i++) {
 			GridField gridField = gridTab.getField(i);
@@ -154,7 +164,7 @@ public class DefaultGridTabSerializer implements IGridTabSerializer, IGridTabSer
 				}
 			}
 			
-			Object value = TypeConverterUtils.fromJsonValue(gridField, jsonField);
+			Object value = TypeConverterUtils.fromJsonValue(gridField, jsonField, trxName);
 			Object oldValue = gridField.getValue();
 			if (value == null && oldValue == null)
 				continue;

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/DefaultPOSerializer.java
@@ -69,11 +69,16 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 
 	@Override
 	public JsonObject toJson(PO po, String[] includes, String[] excludes) {
-		return toJson(po, null, includes, excludes);				
+		return toJson(po, null, includes, excludes, null);
 	}
-	
+
 	@Override
 	public JsonObject toJson(PO po, MRestView view, String[] includes, String[] excludes) {
+		return toJson(po, view, includes, excludes, null);
+	}
+
+	@Override
+	public JsonObject toJson(PO po, MRestView view, String[] includes, String[] excludes, String trxName) {
 		JsonObject json = new JsonObject();
 		MTable table = MTable.get(po.get_Table_ID());
 		String keyColumn = null;
@@ -134,8 +139,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				//get property name from view definition or default conversion
 				String propertyName = viewColumn != null ? viewColumn.getName()
 						: MSysConfig.getBooleanValue("REST_COLUMNNAME_TOLOWERCASE", false) ? TypeConverterUtils.toPropertyName(columnName) : columnName;
-				Object jsonValue = TypeConverterUtils.toJsonValue(column, value, viewColumn != null && viewColumn.getREST_ReferenceView_ID() > 0 
-						? MRestView.get(viewColumn.getREST_ReferenceView_ID()) : null);
+				Object jsonValue = TypeConverterUtils.toJsonValue(column, value, viewColumn != null && viewColumn.getREST_ReferenceView_ID() > 0
+						? MRestView.get(viewColumn.getREST_ReferenceView_ID()) : null, trxName);
 				if (jsonValue != null) {					
 					JsonObject target = json;
 					//rest view support json path mapping to nested json value object
@@ -182,11 +187,16 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 
 	@Override
 	public PO fromJson(JsonObject json, MTable table) {
-		return fromJson(json, table, null);
+		return fromJson(json, table, (MRestView)null, (String)null);
 	}
-	
+
 	@Override
 	public PO fromJson(JsonObject json, MTable table, MRestView view) {
+		return fromJson(json, table, view, null);
+	}
+
+	@Override
+	public PO fromJson(JsonObject json, MTable table, MRestView view, String trxName) {
 		PO po = table.isUUIDKeyTable() ? table.getPOByUU(PO.UUID_NEW_RECORD, null) : table.getPO(0, null);
 		POInfo poInfo = POInfo.getPOInfo(Env.getCtx(), table.getAD_Table_ID());
 		validateJsonFields(json, po, view);
@@ -233,8 +243,8 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 					continue;
 				}
 			}
-			Object value = TypeConverterUtils.fromJsonValue(column, field, viewColumn != null && viewColumn.getREST_ReferenceView_ID() > 0 
-					? MRestView.get(viewColumn.getREST_ReferenceView_ID()) : null);
+			Object value = TypeConverterUtils.fromJsonValue(column, field, viewColumn != null && viewColumn.getREST_ReferenceView_ID() > 0
+					? MRestView.get(viewColumn.getREST_ReferenceView_ID()) : null, trxName);
 			if (! isValueUpdated(po.get_ValueOfColumn(column.getAD_Column_ID()), value))
 				continue;
 			if (viewColumn != null && !Util.isEmpty(viewColumn.getReadOnlyLogic(), true)) {
@@ -262,11 +272,16 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 
 	@Override
 	public PO fromJson(JsonObject json, PO po) {
-		return fromJson(json, po, null);
+		return fromJson(json, po, (MRestView)null, (String)null);
 	}
-	
+
 	@Override
 	public PO fromJson(JsonObject json, PO po, MRestView view) {
+		return fromJson(json, po, view, null);
+	}
+
+	@Override
+	public PO fromJson(JsonObject json, PO po, MRestView view, String trxName) {
 		MTable table = MTable.get(Env.getCtx(), po.get_Table_ID());
 		POInfo poInfo = POInfo.getPOInfo(Env.getCtx(), table.getAD_Table_ID());
 		validateJsonFields(json, po, view);
@@ -308,7 +323,7 @@ public class DefaultPOSerializer implements IPOSerializer, IPOSerializerFactory 
 				if (field == null)
 					continue;
 			}
-			Object value = TypeConverterUtils.fromJsonValue(column, field);
+			Object value = TypeConverterUtils.fromJsonValue(column, field, null, trxName);
 			if (! isValueUpdated(po.get_ValueOfColumn(column.getAD_Column_ID()), value))
 				continue;
 			MRestViewColumn viewColumn = viewColumns != null ? viewColumns[i] : null;

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/IGridTabSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/IGridTabSerializer.java
@@ -44,9 +44,19 @@ public interface IGridTabSerializer {
 	 * @return JsonObject
 	 */
 	public default JsonObject toJson(GridTab gridTab) {
-		return toJson(gridTab, null, null);
+		return toJson(gridTab, (String[])null, (String[])null, (String)null);
 	}
-	
+
+	/**
+	 * Convert current row to json within the given transaction
+	 * @param gridTab
+	 * @param trxName transaction name, or null to read committed data
+	 * @return JsonObject
+	 */
+	public default JsonObject toJson(GridTab gridTab, String trxName) {
+		return toJson(gridTab, (String[])null, (String[])null, trxName);
+	}
+
 	/**
 	 * Convert current row to json
 	 * @param gridTab
@@ -55,13 +65,35 @@ public interface IGridTabSerializer {
 	 * @return JsonObject
 	 */
 	public JsonObject toJson(GridTab gridTab, String[] includes, String[] excludes);
-	
+
+	/**
+	 * Convert current row to json within the given transaction
+	 * @param gridTab
+	 * @param includes columns to include
+	 * @param excludes columns to exclude
+	 * @param trxName transaction name, or null to read committed data
+	 * @return JsonObject
+	 */
+	public default JsonObject toJson(GridTab gridTab, String[] includes, String[] excludes, String trxName) {
+		return toJson(gridTab, includes, excludes);
+	}
+
 	/**
 	 * Copy values from JsonObject to GridTab
 	 * @param json
-	 * @param gridTab 
+	 * @param gridTab
 	 */
 	public void fromJson(JsonObject json, GridTab gridTab);
+
+	/**
+	 * Copy values from JsonObject to GridTab within the given transaction
+	 * @param json
+	 * @param gridTab
+	 * @param trxName transaction name, or null for auto-commit
+	 */
+	public default void fromJson(JsonObject json, GridTab gridTab, String trxName) {
+		fromJson(json, gridTab);
+	}
 	
 	/**
 	 * Get GridTab serializer

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/IPOSerializer.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/IPOSerializer.java
@@ -48,7 +48,17 @@ public interface IPOSerializer {
 	 * @return JsonObject
 	 */
 	public default JsonObject toJson(PO po) {
-		return toJson(po, (String[])null, (String[])null);
+		return toJson(po, (MRestView)null, (String[])null, (String[])null, (String)null);
+	}
+
+	/**
+	 * Transform PO to JsonObject within the given transaction
+	 * @param po
+	 * @param trxName transaction name, or null to read committed data
+	 * @return JsonObject
+	 */
+	public default JsonObject toJson(PO po, String trxName) {
+		return toJson(po, (MRestView)null, (String[])null, (String[])null, trxName);
 	}
 
 	/**
@@ -58,9 +68,20 @@ public interface IPOSerializer {
 	 * @return JsonObject
 	 */
 	public default JsonObject toJson(PO po, MRestView view) {
-		return toJson(po, view, (String[])null, (String[])null);
+		return toJson(po, view, (String[])null, (String[])null, (String)null);
 	}
-	
+
+	/**
+	 * Transform PO to JsonObject within the given transaction
+	 * @param po
+	 * @param view
+	 * @param trxName transaction name, or null to read committed data
+	 * @return JsonObject
+	 */
+	public default JsonObject toJson(PO po, MRestView view, String trxName) {
+		return toJson(po, view, (String[])null, (String[])null, trxName);
+	}
+
 	/**
 	 * Transform PO to JsonObject
 	 * @param po
@@ -69,7 +90,7 @@ public interface IPOSerializer {
 	 * @return JsonObject
 	 */
 	public JsonObject toJson(PO po, String[] includes, String[] excludes);
-	
+
 	/**
 	 * Transform PO to JsonObject
 	 * @param po
@@ -81,7 +102,20 @@ public interface IPOSerializer {
 	public default JsonObject toJson(PO po, MRestView view, String[] includes, String[] excludes) {
 		return toJson(po, includes, excludes);
 	}
-	
+
+	/**
+	 * Transform PO to JsonObject within the given transaction
+	 * @param po
+	 * @param view
+	 * @param includes columns to include
+	 * @param excludes columns to exclude
+	 * @param trxName transaction name, or null to read committed data
+	 * @return JsonObject
+	 */
+	public default JsonObject toJson(PO po, MRestView view, String[] includes, String[] excludes, String trxName) {
+		return toJson(po, view, includes, excludes);
+	}
+
 	/**
 	 * Transform JsonObject to PO
 	 * @param json
@@ -89,7 +123,7 @@ public interface IPOSerializer {
 	 * @return PO
 	 */
 	public PO fromJson(JsonObject json, MTable table);
-	
+
 	/**
 	 * Transform JsonObject to PO
 	 * @param json
@@ -100,7 +134,19 @@ public interface IPOSerializer {
 	default PO fromJson(JsonObject json, MTable table, MRestView view) {
 		return fromJson(json, table);
 	}
-	
+
+	/**
+	 * Transform JsonObject to PO within the given transaction
+	 * @param json
+	 * @param table
+	 * @param view
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return PO
+	 */
+	default PO fromJson(JsonObject json, MTable table, MRestView view, String trxName) {
+		return fromJson(json, table, view);
+	}
+
 	/**
 	 * Copy values from JsonObject to PO
 	 * @param json
@@ -108,7 +154,7 @@ public interface IPOSerializer {
 	 * @return PO
 	 */
 	public PO fromJson(JsonObject json, PO po);
-	
+
 	/**
 	 * Copy values from JsonObject to PO
 	 * @param json
@@ -118,6 +164,18 @@ public interface IPOSerializer {
 	 */
 	default PO fromJson(JsonObject json, PO po, MRestView view) {
 		return fromJson(json, po);
+	}
+
+	/**
+	 * Copy values from JsonObject to PO within the given transaction
+	 * @param json
+	 * @param po
+	 * @param view
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return PO
+	 */
+	default PO fromJson(JsonObject json, PO po, MRestView view, String trxName) {
+		return fromJson(json, po, view);
 	}
 	
 	/**

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ITypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ITypeConverter.java
@@ -57,7 +57,22 @@ public interface ITypeConverter<T> {
 	default Object toJsonValue(MColumn column, T value, MRestView referenceView) {
 		return toJsonValue(column, value);
 	}
-	
+
+	/**
+	 * Convert AD type to json type within the given transaction.
+	 * <p>Converters that read a referenced model (e.g. C_Location, AD_Image) must use
+	 * {@code trxName} so rows co-created earlier in the same still-open request transaction
+	 * are visible. The default ignores {@code trxName} for converters that do not read the DB.
+	 * @param column
+	 * @param value
+	 * @param referenceView
+	 * @param trxName transaction name, or null to read committed data
+	 * @return Object
+	 */
+	default Object toJsonValue(MColumn column, T value, MRestView referenceView, String trxName) {
+		return toJsonValue(column, value, referenceView);
+	}
+
 	/**
 	 * Convert AD type to json type
 	 * @param field
@@ -67,13 +82,24 @@ public interface ITypeConverter<T> {
 	public Object toJsonValue(GridField field, T value);
 
 	/**
+	 * Convert AD type to json type within the given transaction.
+	 * @param field
+	 * @param value
+	 * @param trxName transaction name, or null to read committed data
+	 * @return Object
+	 */
+	default Object toJsonValue(GridField field, T value, String trxName) {
+		return toJsonValue(field, value);
+	}
+
+	/**
 	 * Convert json type to AD type
 	 * @param column
 	 * @param value
 	 * @return Object
 	 */
 	public Object fromJsonValue(MColumn column, JsonElement value);
-	
+
 	/**
 	 * Convert json type to AD type
 	 * @param column
@@ -84,7 +110,22 @@ public interface ITypeConverter<T> {
 	default Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView) {
 		return fromJsonValue(column, value);
 	}
-	
+
+	/**
+	 * Convert json type to AD type within the given transaction.
+	 * <p>Converters that write or resolve a referenced model (e.g. C_Location, AD_Image, lookups)
+	 * must use {@code trxName} so the write participates in the caller's transaction and is rolled
+	 * back with it. The default ignores {@code trxName} for converters that do not touch the DB.
+	 * @param column
+	 * @param value
+	 * @param referenceView
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return Object
+	 */
+	default Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView, String trxName) {
+		return fromJsonValue(column, value, referenceView);
+	}
+
 	/**
 	 * Convert json type to AD type
 	 * @param field
@@ -92,4 +133,15 @@ public interface ITypeConverter<T> {
 	 * @return Object
 	 */
 	public Object fromJsonValue(GridField field, JsonElement value);
+
+	/**
+	 * Convert json type to AD type within the given transaction.
+	 * @param field
+	 * @param value
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return Object
+	 */
+	default Object fromJsonValue(GridField field, JsonElement value, String trxName) {
+		return fromJsonValue(field, value);
+	}
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ImageTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ImageTypeConverter.java
@@ -68,8 +68,8 @@ public class ImageTypeConverter implements ITypeConverter<Object> {
 			return null;
 		}
 
-		MImage img = MImage.get((Integer)value);
-		if (img == null) {
+		MImage img = new MImage(Env.getCtx(), (Integer)value, ThreadLocalTrx.getTrxName());
+		if (img.get_ID() <= 0) {
 			return null;
 		}
 

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ImageTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/ImageTypeConverter.java
@@ -37,7 +37,7 @@ import org.compiere.util.Util;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.trekglobal.idempiere.rest.api.util.ThreadLocalTrx;
+import com.trekglobal.idempiere.rest.api.model.MRestView;
 
 /**
  * json type converter for AD_Image
@@ -54,21 +54,31 @@ public class ImageTypeConverter implements ITypeConverter<Object> {
 
 	@Override
 	public Object toJsonValue(MColumn column, Object value) {
+		return toJsonValue(column, value, (MRestView)null, (String)null);
+	}
+
+	@Override
+	public Object toJsonValue(MColumn column, Object value, MRestView referenceView, String trxName) {
 		String label = Msg.getElement(Env.getCtx(), column.getColumnName());
-		return toJsonValue(label, value);
+		return toJsonValue(label, value, trxName);
 	}
 
 	@Override
 	public Object toJsonValue(GridField field, Object value) {
-		return toJsonValue(field.getHeader(), value);
+		return toJsonValue(field, value, (String)null);
 	}
 
-	private Object toJsonValue(String label, Object value) {
+	@Override
+	public Object toJsonValue(GridField field, Object value, String trxName) {
+		return toJsonValue(field.getHeader(), value, trxName);
+	}
+
+	private Object toJsonValue(String label, Object value, String trxName) {
 		if (value == null) {
 			return null;
 		}
 
-		MImage img = new MImage(Env.getCtx(), (Integer)value, ThreadLocalTrx.getTrxName());
+		MImage img = new MImage(Env.getCtx(), (Integer)value, trxName);
 		if (img.get_ID() <= 0) {
 			return null;
 		}
@@ -92,15 +102,29 @@ public class ImageTypeConverter implements ITypeConverter<Object> {
 		
 	@Override
 	public Object fromJsonValue(GridField field, JsonElement value) {
-		return fromJson(value);
+		return fromJsonValue(field, value, (String)null);
+	}
+
+	@Override
+	public Object fromJsonValue(GridField field, JsonElement value, String trxName) {
+		return fromJson(value, trxName);
 	}
 
 	@Override
 	public Object fromJsonValue(MColumn column, JsonElement value) {
-		return fromJson(value);
+		return fromJsonValue(column, value, (MRestView)null, (String)null);
 	}
-	
+
+	@Override
+	public Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView, String trxName) {
+		return fromJson(value, trxName);
+	}
+
 	public Object fromJson(JsonElement value) {
+		return fromJson(value, null);
+	}
+
+	public Object fromJson(JsonElement value, String trxName) {
 		if (value != null && value.isJsonObject()) {
 		
 			JsonObject ref = value.getAsJsonObject();
@@ -128,7 +152,7 @@ public class ImageTypeConverter implements ITypeConverter<Object> {
 				fileURL = primitive.getAsString();
 			}
 
-			MImage image = new MImage(Env.getCtx(), AD_Image_ID, ThreadLocalTrx.getTrxName());
+			MImage image = new MImage(Env.getCtx(), AD_Image_ID, trxName);
 			JsonElement data = ref.get("data");
 			if (data != null) {
 				if (fileName != null)

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
@@ -118,34 +118,35 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 			
 			MRestViewColumn[] viewColumns = referenceView != null ? referenceView.getColumns() : null;
 			int count = viewColumns != null ? viewColumns.length : columns.length;
-			if (loc != null && loc.get_ID() > 0)
-			for(int i = 0; i < count; i++) {
-				MColumn column = viewColumns != null ? MColumn.get(viewColumns[i].getAD_Column_ID()) : columns[i];
-				if(column.isKey())continue;
-				
-				columnName = column.getColumnName();
-				
-				if (columnName.endsWith("_ID")) {
-					if((columnValue = loc.get_Value(columnName))!=null) {
-						JsonObject refChild = new JsonObject();
-						if (viewColumns == null)
-							refChild.addProperty("propertyLabel",Msg.getElement(Env.getCtx(), columnName));
-						if (value instanceof Number)
-							refChild.addProperty("id", (Integer)columnValue);
-						else
-							refChild.addProperty("id", value.toString());
-						String displayValue = getColumnLookup(column).getDisplay(columnValue);
-						if(displayValue!=null)
-							refChild.addProperty("identifier",displayValue);
-						if (viewColumns != null && viewColumns[i].getREST_ReferenceView_ID() > 0)
-							refChild.addProperty("view-name", MRestView.get(viewColumns[i].getREST_ReferenceView_ID()).getName());
-						else
-							refChild.addProperty("model-name", MTable.get(Env.getCtx(), columnName.replace("_ID", "")).getTableName().toLowerCase());
-						ref.add(viewColumns != null ? viewColumns[i].getName() : columnName, refChild);
-					}
-				} else {
-					if((columnValue = loc.get_Value(columnName))!=null) {
-						ref.addProperty(viewColumns != null ? viewColumns[i].getName() : columnName, columnValue.toString());
+			if (loc != null && loc.get_ID() > 0) {
+				for(int i = 0; i < count; i++) {
+					MColumn column = viewColumns != null ? MColumn.get(viewColumns[i].getAD_Column_ID()) : columns[i];
+					if(column.isKey())continue;
+					
+					columnName = column.getColumnName();
+					
+					if (columnName.endsWith("_ID")) {
+						if((columnValue = loc.get_Value(columnName))!=null) {
+							JsonObject refChild = new JsonObject();
+							if (viewColumns == null)
+								refChild.addProperty("propertyLabel",Msg.getElement(Env.getCtx(), columnName));
+							if (value instanceof Number)
+								refChild.addProperty("id", (Integer)columnValue);
+							else
+								refChild.addProperty("id", value.toString());
+							String displayValue = getColumnLookup(column).getDisplay(columnValue);
+							if(displayValue!=null)
+								refChild.addProperty("identifier",displayValue);
+							if (viewColumns != null && viewColumns[i].getREST_ReferenceView_ID() > 0)
+								refChild.addProperty("view-name", MRestView.get(viewColumns[i].getREST_ReferenceView_ID()).getName());
+							else
+								refChild.addProperty("model-name", MTable.get(Env.getCtx(), columnName.replace("_ID", "")).getTableName().toLowerCase());
+							ref.add(viewColumns != null ? viewColumns[i].getName() : columnName, refChild);
+						}
+					} else {
+						if((columnValue = loc.get_Value(columnName))!=null) {
+							ref.addProperty(viewColumns != null ? viewColumns[i].getName() : columnName, columnValue.toString());
+						}
 					}
 				}
 			}

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
@@ -114,7 +114,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 				ref.addProperty("id", ((Number)value).intValue());
 			else
 				ref.addProperty("id", value.toString());
-			String display = lookup.getDisplay(value);
+			String display = TypeConverterUtils.getIdentifier(lookup, value, trxName);
 			if (!Util.isEmpty(display, true)) {
 				ref.addProperty("identifier", display);
 			}							
@@ -143,7 +143,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 								refChild.addProperty("id", (Integer)columnValue);
 							else
 								refChild.addProperty("id", value.toString());
-							String displayValue = getColumnLookup(column).getDisplay(columnValue);
+							String displayValue = TypeConverterUtils.getIdentifier(getColumnLookup(column), columnValue, trxName);
 							if(displayValue!=null)
 								refChild.addProperty("identifier",displayValue);
 							if (viewColumns != null && viewColumns[i].getREST_ReferenceView_ID() > 0)

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
@@ -97,7 +97,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 	
 	private Object toJsonValue(int displayType, String label, Lookup lookup, String refTableName, Object value, MRestView referenceView) {
 		if (lookup != null && value != null && value instanceof Integer) {
-			MLocation loc = MLocation.get((Integer)value);
+			MLocation loc = new MLocation(Env.getCtx(), (Integer)value, ThreadLocalTrx.getTrxName());
 			JsonObject ref = new JsonObject();
 			if (referenceView == null)
 				ref.addProperty("propertyLabel", label);
@@ -118,6 +118,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 			
 			MRestViewColumn[] viewColumns = referenceView != null ? referenceView.getColumns() : null;
 			int count = viewColumns != null ? viewColumns.length : columns.length;
+			if (loc != null && loc.get_ID() > 0)
 			for(int i = 0; i < count; i++) {
 				MColumn column = viewColumns != null ? MColumn.get(viewColumns[i].getAD_Column_ID()) : columns[i];
 				if(column.isKey())continue;

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LocationTypeConverter.java
@@ -48,7 +48,6 @@ import com.google.gson.JsonPrimitive;
 
 import com.trekglobal.idempiere.rest.api.model.MRestView;
 import com.trekglobal.idempiere.rest.api.model.MRestViewColumn;
-import com.trekglobal.idempiere.rest.api.util.ThreadLocalTrx;
 
 /**
  * json type converter for C_Location
@@ -66,19 +65,29 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 
 	@Override
 	public Object toJsonValue(MColumn column, Object value) {
-		return toJsonValue(column, value, null);
+		return toJsonValue(column, value, (MRestView)null, (String)null);
 	}
-	
+
 	@Override
 	public Object toJsonValue(MColumn column, Object value, MRestView referenceView) {
+		return toJsonValue(column, value, referenceView, (String)null);
+	}
+
+	@Override
+	public Object toJsonValue(MColumn column, Object value, MRestView referenceView, String trxName) {
 		String label = Msg.getElement(Env.getCtx(), column.getColumnName());
 		Lookup lookup = new MLocationLookup(Env.getCtx(), 0);
-		return toJsonValue(column.getAD_Reference_ID(), label, lookup, column.getReferenceTableName(), value, referenceView);
+		return toJsonValue(column.getAD_Reference_ID(), label, lookup, column.getReferenceTableName(), value, referenceView, trxName);
 	}
 
 	@Override
 	public Object toJsonValue(GridField field, Object value) {
-		return toJsonValue(field.getDisplayType(), field.getHeader(), field.getLookup(), getReferenceTableNameFromField(field), value, null);
+		return toJsonValue(field, value, (String)null);
+	}
+
+	@Override
+	public Object toJsonValue(GridField field, Object value, String trxName) {
+		return toJsonValue(field.getDisplayType(), field.getHeader(), field.getLookup(), getReferenceTableNameFromField(field), value, null, trxName);
 	}
 	
 	private String getReferenceTableNameFromField(GridField field) {
@@ -95,9 +104,9 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 		return refTableName;
 	}
 	
-	private Object toJsonValue(int displayType, String label, Lookup lookup, String refTableName, Object value, MRestView referenceView) {
+	private Object toJsonValue(int displayType, String label, Lookup lookup, String refTableName, Object value, MRestView referenceView, String trxName) {
 		if (lookup != null && value != null && value instanceof Integer) {
-			MLocation loc = new MLocation(Env.getCtx(), (Integer)value, ThreadLocalTrx.getTrxName());
+			MLocation loc = new MLocation(Env.getCtx(), (Integer)value, trxName);
 			JsonObject ref = new JsonObject();
 			if (referenceView == null)
 				ref.addProperty("propertyLabel", label);
@@ -158,24 +167,38 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 		
 	@Override
 	public Object fromJsonValue(GridField field, JsonElement value) {
-		return fromJson(value);
+		return fromJsonValue(field, value, (String)null);
+	}
+
+	@Override
+	public Object fromJsonValue(GridField field, JsonElement value, String trxName) {
+		return fromJson(value, null, trxName);
 	}
 
 	@Override
 	public Object fromJsonValue(MColumn column, JsonElement value) {
-		return fromJsonValue(column, value, null);
+		return fromJsonValue(column, value, (MRestView)null, (String)null);
 	}
-	
+
 	@Override
 	public Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView) {
-		return fromJson(value, referenceView);
+		return fromJsonValue(column, value, referenceView, (String)null);
 	}
-	
+
+	@Override
+	public Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView, String trxName) {
+		return fromJson(value, referenceView, trxName);
+	}
+
 	public Object fromJson(JsonElement element) {
-		return fromJson(element, null);
+		return fromJson(element, null, null);
 	}
-	
+
 	public Object fromJson(JsonElement element, MRestView referenceView) {
+		return fromJson(element, referenceView, null);
+	}
+
+	public Object fromJson(JsonElement element, MRestView referenceView, String trxName) {
 		if (element != null && element.isJsonObject()) {
 		
 			JsonObject json = element.getAsJsonObject();
@@ -189,7 +212,7 @@ public class LocationTypeConverter implements ITypeConverter<Object> {
 					C_Location_ID = 0;
 			}
 
-			MLocation po = new MLocation(Env.getCtx(), C_Location_ID, ThreadLocalTrx.getTrxName());
+			MLocation po = new MLocation(Env.getCtx(), C_Location_ID, trxName);
 
 			MTable table = MTable.get(Env.getCtx(), MLocation.Table_ID);
 			POInfo poInfo = POInfo.getPOInfo(Env.getCtx(), table.getAD_Table_ID());

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LookupTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LookupTypeConverter.java
@@ -61,7 +61,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.trekglobal.idempiere.rest.api.model.MRestView;
-import com.trekglobal.idempiere.rest.api.util.ThreadLocalTrx;
 
 /**
  * json type converter for AD lookup type
@@ -78,28 +77,48 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 
 	@Override
 	public Object toJsonValue(MColumn column, Object value) {
-		return toJsonValue(column, value, null);
+		return toJsonValue(column, value, (MRestView)null, (String)null);
 	}
-	
+
 	@Override
 	public Object toJsonValue(MColumn column, Object value, MRestView referenceView) {
+		return toJsonValue(column, value, referenceView, (String)null);
+	}
+
+	@Override
+	public Object toJsonValue(MColumn column, Object value, MRestView referenceView, String trxName) {
 		String label = Msg.getElement(Env.getCtx(), column.getColumnName());
-		return toJsonValue(column.getAD_Reference_ID(), label, getColumnLookup(column), column.getReferenceTableName(), value, referenceView);
+		return toJsonValue(column.getAD_Reference_ID(), label, getColumnLookup(column), column.getReferenceTableName(), value, referenceView, trxName);
 	}
 
 	@Override
 	public Object toJsonValue(GridField field, Object value) {
-		return toJsonValue(field.getDisplayType(), field.getHeader(), field.getLookup(), getReferenceTableNameFromField(field), value, null);
+		return toJsonValue(field, value, (String)null);
+	}
+
+	@Override
+	public Object toJsonValue(GridField field, Object value, String trxName) {
+		return toJsonValue(field.getDisplayType(), field.getHeader(), field.getLookup(), getReferenceTableNameFromField(field), value, null, trxName);
 	}
 
 	@Override
 	public Object fromJsonValue(MColumn column, JsonElement value) {
-		return fromJsonValue(column.getAD_Reference_ID(), column.getReferenceTableName(), value, column.getAD_Reference_Value_ID());
+		return fromJsonValue(column, value, (MRestView)null, (String)null);
+	}
+
+	@Override
+	public Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView, String trxName) {
+		return fromJsonValue(column.getAD_Reference_ID(), column.getReferenceTableName(), value, column.getAD_Reference_Value_ID(), trxName);
 	}
 
 	@Override
 	public Object fromJsonValue(GridField field, JsonElement value) {
-		return fromJsonValue(field.getDisplayType(), getReferenceTableNameFromField(field), value, field.getAD_Reference_Value_ID());
+		return fromJsonValue(field, value, (String)null);
+	}
+
+	@Override
+	public Object fromJsonValue(GridField field, JsonElement value, String trxName) {
+		return fromJsonValue(field.getDisplayType(), getReferenceTableNameFromField(field), value, field.getAD_Reference_Value_ID(), trxName);
 	}
 	
 	private String getReferenceTableNameFromField(GridField field) {
@@ -116,15 +135,15 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		return refTableName;
 	}
 
-	private Object toJsonValue(int displayType, String label, Lookup lookup, String refTableName, Object value, MRestView referenceView) {
+	private Object toJsonValue(int displayType, String label, Lookup lookup, String refTableName, Object value, MRestView referenceView, String trxName) {
 		if (lookup != null && value != null) {
 			JsonObject ref = new JsonObject();
 			if (referenceView == null)
 				ref.addProperty("propertyLabel", label);
 			if (displayType == DisplayType.ChosenMultipleSelectionSearch || displayType == DisplayType.ChosenMultipleSelectionTable) {
-				return toJsonValueForChosenMultipleSelectionTable(lookup, refTableName, value, referenceView, ref);
+				return toJsonValueForChosenMultipleSelectionTable(lookup, refTableName, value, referenceView, ref, trxName);
 			}
-			addRecordIdProperty(lookup, refTableName, value, referenceView, ref);
+			addRecordIdProperty(lookup, refTableName, value, referenceView, ref, trxName);
 			return ref;
 		} else {
 			return null;
@@ -132,13 +151,13 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 	}
 
 	private Object toJsonValueForChosenMultipleSelectionTable(Lookup lookup, String refTableName, Object value,
-			MRestView referenceView, JsonObject ref) {
+			MRestView referenceView, JsonObject ref, String trxName) {
 		JsonArray array = new JsonArray();
 		String[] values = value.toString().split(",");
 		if (values.length > 0) {
 			for(String v : values) {
 				JsonObject item = new JsonObject();
-				addRecordIdProperty(lookup, refTableName, v, referenceView, item);
+				addRecordIdProperty(lookup, refTableName, v, referenceView, item, trxName);
 				array.add(item);
 			}
 		}
@@ -147,7 +166,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 	}
 
 	private void addRecordIdProperty(Lookup lookup, String refTableName, Object value, MRestView referenceView,
-			JsonObject ref) {
+			JsonObject ref, String trxName) {
 		if (value instanceof Number)
 			ref.addProperty("id", ((Number)value).intValue());
 		else
@@ -164,7 +183,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 			if (RestUtils.isReturnUULookup(refTableName)) {
 				String uidColumn = PO.getUUIDColumnName(refTableName);
 				String keyColumn = RestUtils.getKeyColumnName(refTableName);
-				String uuid = DB.getSQLValueString(ThreadLocalTrx.getTrxName(), "SELECT " + uidColumn + " FROM " + refTableName + " WHERE " + keyColumn + "=?", value);
+				String uuid = DB.getSQLValueString(trxName, "SELECT " + uidColumn + " FROM " + refTableName + " WHERE " + keyColumn + "=?", value);
 				if (!Util.isEmpty(uuid))
 					ref.addProperty("uuid", uuid);
 			}
@@ -226,20 +245,20 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		return lookup;
 	}
 	
-	private Object fromJsonValue(int displayType, String refTableName, JsonElement value, int AD_Reference_Value_ID) {
+	private Object fromJsonValue(int displayType, String refTableName, JsonElement value, int AD_Reference_Value_ID, String trxName) {
 		if (value != null && value.isJsonObject()) {
 			if (displayType == DisplayType.ChosenMultipleSelectionSearch || displayType == DisplayType.ChosenMultipleSelectionTable) {
-				return fromJsonValueForChosenMultipleSelectionTable(refTableName, value.getAsJsonObject(), AD_Reference_Value_ID);
+				return fromJsonValueForChosenMultipleSelectionTable(refTableName, value.getAsJsonObject(), AD_Reference_Value_ID, trxName);
 			}
 			JsonObject ref = value.getAsJsonObject();
-			Object id = findRecordId(ref, refTableName, AD_Reference_Value_ID);
+			Object id = findRecordId(ref, refTableName, AD_Reference_Value_ID, trxName);
 			if (id != null)
 				return id;
 			else
 				throw new AdempiereException("Could not convert value " + value + " for " + refTableName);
 		} else if (value != null && value.isJsonArray() &&
 			(displayType == DisplayType.ChosenMultipleSelectionSearch || displayType == DisplayType.ChosenMultipleSelectionTable)) {
-			return fromJsonValueForChosenMultipleSelectionTable(refTableName, value, AD_Reference_Value_ID);
+			return fromJsonValueForChosenMultipleSelectionTable(refTableName, value, AD_Reference_Value_ID, trxName);
 		} else if (value != null && value.isJsonPrimitive()) {
 			JsonPrimitive primitive = (JsonPrimitive) value;
 			if (primitive.isNumber())
@@ -255,7 +274,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		}
 	}
 
-	private Object fromJsonValueForChosenMultipleSelectionTable(String refTableName, JsonElement value, int AD_Reference_Value_ID) {
+	private Object fromJsonValueForChosenMultipleSelectionTable(String refTableName, JsonElement value, int AD_Reference_Value_ID, String trxName) {
 		JsonArray array = null;
 		if (value.isJsonArray()) {
 			array = value.getAsJsonArray();
@@ -271,7 +290,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 			for (JsonElement el : array) {
 				if (el.isJsonObject()) {
 					JsonObject ref = el.getAsJsonObject();
-					Object id = findRecordId(ref, refTableName, AD_Reference_Value_ID);
+					Object id = findRecordId(ref, refTableName, AD_Reference_Value_ID, trxName);
 					if (id != null) {
 						if (sb.length() > 0)
 							sb.append(",");
@@ -299,7 +318,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		throw new AdempiereException("Could not convert value " + value + " for " + refTableName);
 	}
 
-	private Object findRecordId(JsonObject ref, String refTableName, int AD_Reference_Value_ID) {
+	private Object findRecordId(JsonObject ref, String refTableName, int AD_Reference_Value_ID, String trxName) {
 		JsonElement idField = ref.get("id");
 		if (idField != null) {
 			JsonPrimitive primitive = (JsonPrimitive) idField;
@@ -310,16 +329,16 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		}
 		JsonElement identifier = ref.get("identifier");
 		if (identifier != null && !Util.isEmpty(refTableName) && !identifier.isJsonNull()) {
-			int id = findId(refTableName, identifier, AD_Reference_Value_ID);
+			int id = findId(refTableName, identifier, AD_Reference_Value_ID, trxName);
 			if (id >= 0)
 				return id;
 		}
-		
+
 		JsonElement uidField = ref.get("uid");
 		if (uidField != null && !Util.isEmpty(refTableName) && !uidField.isJsonNull()) {
 			String uidColumn = PO.getUUIDColumnName(refTableName);
 			String keyColumn = RestUtils.getKeyColumnName(refTableName);
-			int id = DB.getSQLValue(ThreadLocalTrx.getTrxName(), "SELECT " + keyColumn + " FROM " + refTableName + " WHERE " + uidColumn + "=?", uidField.getAsString());
+			int id = DB.getSQLValue(trxName, "SELECT " + keyColumn + " FROM " + refTableName + " WHERE " + uidColumn + "=?", uidField.getAsString());
 			if (id > 0)
 				return id;
 		}
@@ -328,7 +347,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 			uidField = ref;
 			JsonElement searchValue = ref.get("lookupValue");
 
-			int id = findIdbyColumn(refTableName, columnName.getAsString(), searchValue);
+			int id = findIdbyColumn(refTableName, columnName.getAsString(), searchValue, trxName);
 			if (id >= 0)
 				return id;
 		}
@@ -341,13 +360,13 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 	 * @param identifier
 	 * @return
 	 */
-	private int findId(String tableName, JsonElement identifier, int AD_Reference_Value_ID) {
+	private int findId(String tableName, JsonElement identifier, int AD_Reference_Value_ID, String trxName) {
 		MTable table = MTable.get(Env.getCtx(), tableName);
 		// check identifier first for backward compatibility
 		String[] identifiers = table.getIdentifierColumns();
 		if (identifiers != null && identifiers.length > 0) {
 			MColumn column = table.getColumn(identifiers[0]);
-			int id = getFirstIdOnly(table, column, identifier);
+			int id = getFirstIdOnly(table, column, identifier, trxName);
 			if (id >= 0)
 				return id;
 		}
@@ -360,7 +379,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 				if (columnId > 0) {
 					MColumn column = MColumn.get(Env.getCtx(), columnId);
 					if (column != null)
-						return getFirstIdOnly(table, column, identifier);
+						return getFirstIdOnly(table, column, identifier, trxName);
 				}
 			}
 		}
@@ -375,12 +394,12 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 	 * @param searchValue
 	 * @return
 	 */
-	private int findIdbyColumn(String tableName, String columnName, JsonElement searchValue) {
+	private int findIdbyColumn(String tableName, String columnName, JsonElement searchValue, String trxName) {
 		MTable table = MTable.get(Env.getCtx(), tableName);
 		MColumn column = table.getColumn(columnName);
 		if (column == null)
 			throw new AdempiereException("Column not found -> " + tableName + "." + columnName);
-		return getFirstIdOnly(table, column, searchValue);
+		return getFirstIdOnly(table, column, searchValue, trxName);
 	}
 
 	/**
@@ -390,7 +409,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 	 * @param identifier
 	 * @return
 	 */
-	private int getFirstIdOnly(MTable table, MColumn column, JsonElement identifier) {
+	private int getFirstIdOnly(MTable table, MColumn column, JsonElement identifier, String trxName) {
 		int id = -1;
 		String tableName = table.getTableName();
 		StringBuilder builder = new StringBuilder()
@@ -398,7 +417,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 		   .append(" WHERE ").append(column.getColumnName()).append("=?");
 		String sql = MRole.getDefault().addAccessSQL(builder.toString(), tableName, true, false);
 
-		try (PreparedStatement stmt = DB.prepareStatement(sql, null)) {
+		try (PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
 			Object param;
 			if (DisplayType.isID(column.getAD_Reference_ID()))
 				param = identifier.getAsInt();

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LookupTypeConverter.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/LookupTypeConverter.java
@@ -171,7 +171,7 @@ public class LookupTypeConverter implements ITypeConverter<Object> {
 			ref.addProperty("id", ((Number)value).intValue());
 		else
 			ref.addProperty("id", value.toString());
-		String display = lookup.getDisplay(value);
+		String display = TypeConverterUtils.getIdentifier(lookup, value, trxName);
 		if (!Util.isEmpty(display, true)) {
 			ref.addProperty("identifier", display);
 		}							

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/TypeConverterUtils.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/TypeConverterUtils.java
@@ -46,8 +46,10 @@ import java.util.regex.Pattern;
 import org.adempiere.base.Service;
 import org.adempiere.base.ServiceQuery;
 import org.compiere.model.GridField;
+import org.compiere.model.Lookup;
 import org.compiere.model.MColumn;
 import org.compiere.util.DisplayType;
+import org.compiere.util.NamePair;
 import org.compiere.util.Util;
 
 import com.google.gson.JsonElement;
@@ -236,11 +238,31 @@ public class TypeConverterUtils {
 	}
 	
 	/**
+	 * Resolve the display identifier for a lookup value within the given transaction.
+	 * <p>Uses {@link Lookup#getDirect(Object, boolean, boolean, String)} so a referenced row
+	 * co-created earlier in the same still-open request transaction is visible, and falls back
+	 * to the cached {@link Lookup#getDisplay(Object)} when no transaction is supplied or the
+	 * direct read returns nothing.
+	 * @param lookup lookup
+	 * @param value key value
+	 * @param trxName transaction name, or null to read committed data
+	 * @return display identifier
+	 */
+	public static String getIdentifier(Lookup lookup, Object value, String trxName) {
+		if (trxName != null) {
+			NamePair pair = lookup.getDirect(value, false, false, trxName);
+			if (pair != null)
+				return pair.getName();
+		}
+		return lookup.getDisplay(value);
+	}
+
+	/**
 	 * convert arbitrary text to slug
 	 * @param input
 	 * @return slug
 	 */
-	public static String slugify(String input) {  
+	public static String slugify(String input) {
 		String noseparators = SEPARATORS.matcher(input).replaceAll("-");
 	    String normalized = Normalizer.normalize(noseparators, Form.NFD);
 	    String slug = NONLATIN.matcher(normalized).replaceAll("");

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/TypeConverterUtils.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/json/TypeConverterUtils.java
@@ -94,10 +94,9 @@ public class TypeConverterUtils {
 	 * @return Object
 	 */
 	public static Object toJsonValue(MColumn column, Object value) {
-		return toJsonValue(column, value, null);
+		return toJsonValue(column, value, null, null);
 	}
-	
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+
 	/**
 	 * Convert db column value to json value
 	 * @param column
@@ -105,11 +104,24 @@ public class TypeConverterUtils {
 	 * @param referenceView
 	 * @return Object
 	 */
-	public static Object toJsonValue(MColumn column, Object value, MRestView referenceView) {		
+	public static Object toJsonValue(MColumn column, Object value, MRestView referenceView) {
+		return toJsonValue(column, value, referenceView, null);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	/**
+	 * Convert db column value to json value within the given transaction
+	 * @param column
+	 * @param value
+	 * @param referenceView
+	 * @param trxName transaction name, or null to read committed data
+	 * @return Object
+	 */
+	public static Object toJsonValue(MColumn column, Object value, MRestView referenceView, String trxName) {
 		ITypeConverter typeConverter = getTypeConverter(column.getAD_Reference_ID(), value);
-		
+
 		if (typeConverter != null) {
-			return typeConverter.toJsonValue(column, value, referenceView);
+			return typeConverter.toJsonValue(column, value, referenceView, trxName);
 		} else if (value != null && DisplayType.isText(column.getAD_Reference_ID())) {
 			return value.toString();
 		} else if (value != null && column.getAD_Reference_ID() == DisplayType.ID && value instanceof Number) {
@@ -118,19 +130,30 @@ public class TypeConverterUtils {
 			return null;
 		}
 	}
-	
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+
 	/**
 	 * Convert db column value to json value
 	 * @param field
 	 * @param value
 	 * @return Object
 	 */
-	public static Object toJsonValue(GridField field, Object value) {		
+	public static Object toJsonValue(GridField field, Object value) {
+		return toJsonValue(field, value, (String)null);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	/**
+	 * Convert db column value to json value within the given transaction
+	 * @param field
+	 * @param value
+	 * @param trxName transaction name, or null to read committed data
+	 * @return Object
+	 */
+	public static Object toJsonValue(GridField field, Object value, String trxName) {
 		ITypeConverter typeConverter = getTypeConverter(field.getDisplayType(), value);
-		
+
 		if (typeConverter != null) {
-			return typeConverter.toJsonValue(field, value);
+			return typeConverter.toJsonValue(field, value, trxName);
 		} else if (value != null && DisplayType.isText(field.getDisplayType())) {
 			return value.toString();
 		} else if (value != null && field.getDisplayType() == DisplayType.ID && value instanceof Number) {
@@ -139,7 +162,7 @@ public class TypeConverterUtils {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * Convert json value to db column value
 	 * @param column
@@ -147,10 +170,9 @@ public class TypeConverterUtils {
 	 * @return Object
 	 */
 	public static Object fromJsonValue(MColumn column, JsonElement value) {
-		return fromJsonValue(column, value, null);
+		return fromJsonValue(column, value, null, null);
 	}
-	
-	@SuppressWarnings("rawtypes")
+
 	/**
 	 * Convert json value to db column value
 	 * @param column
@@ -158,30 +180,54 @@ public class TypeConverterUtils {
 	 * @param referenceView
 	 * @return Object
 	 */
-	public static Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView) {		
+	public static Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView) {
+		return fromJsonValue(column, value, referenceView, null);
+	}
+
+	@SuppressWarnings("rawtypes")
+	/**
+	 * Convert json value to db column value within the given transaction
+	 * @param column
+	 * @param value
+	 * @param referenceView
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return Object
+	 */
+	public static Object fromJsonValue(MColumn column, JsonElement value, MRestView referenceView, String trxName) {
 		ITypeConverter typeConverter = getTypeConverter(column.getAD_Reference_ID(), value);
-		
+
 		if (typeConverter != null) {
-			return typeConverter.fromJsonValue(column, value, referenceView);
+			return typeConverter.fromJsonValue(column, value, referenceView, trxName);
 		} else if (value != null && !(value instanceof JsonNull) && DisplayType.isText(column.getAD_Reference_ID())) {
 			return value.getAsString();
 		} else {
 			return null;
 		}
 	}
-	
-	@SuppressWarnings("rawtypes")
+
 	/**
 	 * Convert json value to db column value
 	 * @param gridField
 	 * @param value
 	 * @return Object
 	 */
-	public static Object fromJsonValue(GridField gridField, JsonElement value) {		
+	public static Object fromJsonValue(GridField gridField, JsonElement value) {
+		return fromJsonValue(gridField, value, (String)null);
+	}
+
+	@SuppressWarnings("rawtypes")
+	/**
+	 * Convert json value to db column value within the given transaction
+	 * @param gridField
+	 * @param value
+	 * @param trxName transaction name, or null for auto-commit
+	 * @return Object
+	 */
+	public static Object fromJsonValue(GridField gridField, JsonElement value, String trxName) {
 		ITypeConverter typeConverter = getTypeConverter(gridField.getDisplayType(), value);
-		
+
 		if (typeConverter != null) {
-			return typeConverter.fromJsonValue(gridField, value);
+			return typeConverter.fromJsonValue(gridField, value, trxName);
 		} else if (value != null && !(value instanceof JsonNull) && DisplayType.isText(gridField.getDisplayType())) {
 			return value.getAsString();
 		} else {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -441,7 +441,7 @@ public class ModelResourceImpl implements ModelResource {
 			Gson gson = new GsonBuilder().create();
 			JsonObject jsonObject = gson.fromJson(jsonText, JsonObject.class);
 			IPOSerializer serializer = IPOSerializer.getPOSerializer(tableName, MTable.getClass(tableName));
-			PO po = serializer.fromJson(jsonObject, table, view);
+			PO po = serializer.fromJson(jsonObject, table, view, trx.getTrxName());
 			if (po.getAD_Client_ID() != Env.getAD_Client_ID(Env.getCtx())) {
 				log.log(Level.SEVERE, "Tenant " + Env.getAD_Client_ID(Env.getCtx()) + " attempt to create record for tenant: " + po.getAD_Client_ID(), 
 						new CrossTenantException(true, po.get_TableName(), -1));
@@ -501,7 +501,7 @@ public class ModelResourceImpl implements ModelResource {
 			if (threadLocalTrxName == null)
 				trx.commit(true);
 			po.load(trx.getTrxName());
-			jsonObject = serializer.toJson(po, view);
+			jsonObject = serializer.toJson(po, view, trx.getTrxName());
 			if (processMsg.length() > 0)
 				jsonObject.addProperty("doc-processmsg", processMsg.toString());
 			if (detailMap.size() > 0) {
@@ -568,7 +568,7 @@ public class ModelResourceImpl implements ModelResource {
 					fieldArray.forEach(e -> {
 						if (e.isJsonObject()) {
 							JsonObject childJsonObject = e.getAsJsonObject();
-							PO childPO = childSerializer.fromJson(childJsonObject, childTable, finalChildView);
+							PO childPO = childSerializer.fromJson(childJsonObject, childTable, finalChildView, trx.getTrxName());
 							if (!RestUtils.hasRoleUpdateAccess(childPO.getAD_Client_ID(), childPO.getAD_Org_ID(), childPO.get_Table_ID(), 0, true))
 								throw new AdempiereException("AccessCannotUpdate");
 							
@@ -600,7 +600,7 @@ public class ModelResourceImpl implements ModelResource {
 								EventManager.getInstance().unregister(eventHandler);
 							}
 							fireRestSaveEvent(childPO, PO_AFTER_REST_SAVE, true);
-							childJsonObject = childSerializer.toJson(childPO, finalChildView);
+							childJsonObject = childSerializer.toJson(childPO, finalChildView, trx.getTrxName());
 							JsonObject newChildJsonObject = e.getAsJsonObject();
 							Map<String, JsonArray> childDetailMap = new LinkedHashMap<>();
 							Set<String> fields = newChildJsonObject.keySet();
@@ -672,7 +672,7 @@ public class ModelResourceImpl implements ModelResource {
 			Gson gson = new GsonBuilder().create();
 			JsonObject jsonObject = gson.fromJson(jsonText, JsonObject.class);
 			IPOSerializer serializer = IPOSerializer.getPOSerializer(tableName, MTable.getClass(tableName));
-			po = serializer.fromJson(jsonObject, po, view);			
+			po = serializer.fromJson(jsonObject, po, view, trx.getTrxName());			
 			po.set_TrxName(trx.getTrxName());
 
 			// Event handler for mandatory fields validation
@@ -754,10 +754,10 @@ public class ModelResourceImpl implements ModelResource {
 										throw new IDempiereRestException("Delete Error", "Cannot delete non-existing record", Status.NOT_FOUND);
 									
 									if (childPO == null) {
-										childPO = childSerializer.fromJson(childJsonObject, childTable, finalChildView);
+										childPO = childSerializer.fromJson(childJsonObject, childTable, finalChildView, trx.getTrxName());
 										childPO.set_ValueOfColumn(RestUtils.getKeyColumnName(tableName), parentId);
 									} else  if (!delete){
-										childPO = childSerializer.fromJson(childJsonObject, childPO, finalChildView);
+										childPO = childSerializer.fromJson(childJsonObject, childPO, finalChildView, trx.getTrxName());
 									}
 									childPO.set_TrxName(trx.getTrxName());
 									if (delete) {
@@ -790,7 +790,7 @@ public class ModelResourceImpl implements ModelResource {
 											EventManager.getInstance().unregister(childEventHandler);
 										}
 										fireRestSaveEvent(childPO, PO_AFTER_REST_SAVE, false);
-										childJsonObject = serializer.toJson(childPO, finalChildView);
+										childJsonObject = serializer.toJson(childPO, finalChildView, trx.getTrxName());
 										savedArray.add(childJsonObject);
 									}									
 								}
@@ -822,7 +822,7 @@ public class ModelResourceImpl implements ModelResource {
 			}
 			
 			po.load(trx.getTrxName());
-			jsonObject = serializer.toJson(po, view);
+			jsonObject = serializer.toJson(po, view, trx.getTrxName());
 			if (processMsg.length() > 0)
 				jsonObject.addProperty("doc-processmsg", processMsg.toString());
 			if (detailMap.size() > 0) {

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WindowResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WindowResourceImpl.java
@@ -972,7 +972,7 @@ public class WindowResourceImpl implements WindowResource {
 							.build();
 					break;
 				}				
-				serializer.fromJson(jsonObject, gridTab);
+				serializer.fromJson(jsonObject, gridTab, trx.getTrxName());
 				if (save && gridTab.needSave(true, true)) {
 					ErrorDataStatusListener edsl = new ErrorDataStatusListener();
 					gridTab.getTableModel().addDataStatusListener(edsl);
@@ -1018,7 +1018,7 @@ public class WindowResourceImpl implements WindowResource {
 									}
 									gridTab.setValue(gridTab.getLinkColumnName(), recordId);
 								}
-								serializer.fromJson(childJsonObject, gridTab);
+								serializer.fromJson(childJsonObject, gridTab, trx.getTrxName());
 								if (save && gridTab.needSave(true, true)) {
 									if (!gridTab.dataSave(false))  {
 										error[0] = Boolean.TRUE;
@@ -1027,7 +1027,7 @@ public class WindowResourceImpl implements WindowResource {
 										gridTab.dataRefresh(false);
 									}
 								}
-								childJsonObject = serializer.toJson(gridTab);
+								childJsonObject = serializer.toJson(gridTab, trx.getTrxName());
 								updatedArray.add(childJsonObject);
 							}
 						});
@@ -1079,7 +1079,7 @@ public class WindowResourceImpl implements WindowResource {
 		JsonObject updatedJsonObject = null;
 		if (headerTab != null) {
 			IGridTabSerializer serializer = IGridTabSerializer.getGridTabSerializer(headerTab.getAD_Tab_UU());
-			updatedJsonObject = serializer.toJson(headerTab);
+			updatedJsonObject = serializer.toJson(headerTab, trx.getTrxName());
 			if (childMap.size() > 0) {
 				for(String slug : childMap.keySet()) {
 					updatedJsonObject.add(slug, childMap.get(slug));
@@ -1170,7 +1170,7 @@ public class WindowResourceImpl implements WindowResource {
 										.build().toString())
 								.build();
 					}
-					serializer.fromJson(jsonObject, gridTab);
+					serializer.fromJson(jsonObject, gridTab, trx.getTrxName());
 					if (save) {
 						if (!gridTab.dataSave(false))  {
 							trx.rollback();
@@ -1215,7 +1215,7 @@ public class WindowResourceImpl implements WindowResource {
 									return;
 								}
 								gridTab.setValue(gridTab.getLinkColumnName(), finalHeaderTab.getKeyID(0));								
-								serializer.fromJson(childJsonObject, gridTab);
+								serializer.fromJson(childJsonObject, gridTab, trx.getTrxName());
 								if (save) {
 									if (!gridTab.dataSave(false))  {
 										error[0] = Boolean.TRUE;
@@ -1224,7 +1224,7 @@ public class WindowResourceImpl implements WindowResource {
 										gridTab.dataRefresh(false);
 									}
 								}
-								childJsonObject = serializer.toJson(gridTab);
+								childJsonObject = serializer.toJson(gridTab, trx.getTrxName());
 								updatedArray.add(childJsonObject);
 							}
 						});
@@ -1271,7 +1271,7 @@ public class WindowResourceImpl implements WindowResource {
 		JsonObject updatedJsonObject = null;
 		if (headerTab != null) {
 			IGridTabSerializer serializer = IGridTabSerializer.getGridTabSerializer(headerTab.getAD_Tab_UU());
-			updatedJsonObject = serializer.toJson(headerTab);
+			updatedJsonObject = serializer.toJson(headerTab, trx.getTrxName());
 			if (childMap.size() > 0) {
 				for(String slug : childMap.keySet()) {
 					updatedJsonObject.add(slug, childMap.get(slug));


### PR DESCRIPTION
…ialize

issue: #359

LocationTypeConverter and ImageTypeConverter loaded the referenced model via the transaction-less MLocation.get(int)/MImage.get(int), which read committed data only. A row co-created earlier in the same still-open REST transaction was therefore invisible during response serialization: LocationTypeConverter got a null MLocation and NPE'd in the column loop (POST /models with an inline C_Location), and ImageTypeConverter silently dropped the image.

Read within ThreadLocalTrx.getTrxName() via direct construction (mirroring each converter's fromJson write path, avoiding cache pollution) and guard the not-loaded case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON serialization/deserialization reliability by consistently propagating the active transaction context through PO, grid/tab, and window update/create flows.
  - Enhanced image and location conversions to respect the provided transaction name and treat missing/invalid image IDs more safely.
  - Updated lookup/identifier handling to resolve identifiers consistently within the transaction, with a defined fallback when needed.
- **Tests**
  - Updated unit tests to use constructor-based mocking for image/location lookups (replacing static mocking).
  - Added/adjusted tests covering transaction-aware lookup identifier resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->