### PR TITLE
#525 - Inbound webhook: set process user and forward URL query params 

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WebhookInboundResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/WebhookInboundResourceImpl.java
@@ -25,6 +25,9 @@
 **********************************************************************/
 package com.trekglobal.idempiere.rest.api.v1.resource.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -43,6 +46,13 @@ public class WebhookInboundResourceImpl implements WebhookInboundResource {
 	@Override
 	public Response receiveWebhook(String endpointKey, String body, HttpHeaders headers, HttpServletRequest request) {
 		String remoteAddr = request != null ? request.getRemoteAddr() : null;
-		return WebhookInboundHandler.handle(endpointKey, body, headers, remoteAddr);
+		Map<String, String> queryParams = new HashMap<>();
+		if (request != null && request.getParameterMap() != null) {
+			for (Map.Entry<String, String[]> e : request.getParameterMap().entrySet()) {
+				if (e.getValue() != null && e.getValue().length > 0)
+					queryParams.put(e.getKey(), e.getValue()[0]);
+			}
+		}
+		return WebhookInboundHandler.handle(endpointKey, body, queryParams, headers, remoteAddr);
 	}
 }

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/webhook/WebhookInboundHandler.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/webhook/WebhookInboundHandler.java
@@ -209,6 +209,8 @@ public class WebhookInboundHandler {
 					.build();
 		}
 
+		Env.setContext(ctx, Env.AD_USER_ID, userId);
+
 		ProcessInfo pi = new ProcessInfo("Webhook: " + endpointKey, inbound.getAD_Process_ID());
 		pi.setAD_Client_ID(inbound.getAD_Client_ID());
 		pi.setAD_User_ID(userId);

--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/webhook/WebhookInboundHandler.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/webhook/WebhookInboundHandler.java
@@ -25,6 +25,9 @@
 **********************************************************************/
 package com.trekglobal.idempiere.rest.api.webhook;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 
@@ -71,7 +74,8 @@ public class WebhookInboundHandler {
 	private WebhookInboundHandler() {
 	}
 
-	public static Response handle(String endpointKey, String body, HttpHeaders headers, String remoteAddr) {
+	public static Response handle(String endpointKey, String body, Map<String, String> queryParams,
+			HttpHeaders headers, String remoteAddr) {
 		Properties ctx = Env.getCtx();
 
 		// Lookup endpoint by key (before master switch — need AD_Client_ID for client-level SysConfig)
@@ -214,9 +218,16 @@ public class WebhookInboundHandler {
 		ProcessInfo pi = new ProcessInfo("Webhook: " + endpointKey, inbound.getAD_Process_ID());
 		pi.setAD_Client_ID(inbound.getAD_Client_ID());
 		pi.setAD_User_ID(userId);
-		pi.setParameter(new ProcessInfoParameter[] {
-				new ProcessInfoParameter(PROCESS_PARAM_PAYLOAD, body, null, null, null)
-		});
+		List<ProcessInfoParameter> piParams = new ArrayList<>();
+		if (queryParams != null) {
+			for (Map.Entry<String, String> qp : queryParams.entrySet()) {
+				if (qp.getKey() == null || PROCESS_PARAM_PAYLOAD.equals(qp.getKey()))
+					continue;
+				piParams.add(new ProcessInfoParameter(qp.getKey(), qp.getValue(), null, null, null));
+			}
+		}
+		piParams.add(new ProcessInfoParameter(PROCESS_PARAM_PAYLOAD, body, null, null, null));
+		pi.setParameter(piParams.toArray(new ProcessInfoParameter[0]));
 
 		try {
 			ServerProcessCtl.process(pi, null);


### PR DESCRIPTION
Fixes #525



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook requests now support query parameters.
  * Query parameters are forwarded to the configured process as input values.
  * The request payload continues to be provided separately from query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->