### PR TITLE
fix(models): normalize table name to AD_Table.TableName before model class lookup (#532)

### DIFF
--- a/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
+++ b/com.trekglobal.idempiere.rest.api/src/com/trekglobal/idempiere/rest/api/v1/resource/impl/ModelResourceImpl.java
@@ -166,7 +166,8 @@ public class ModelResourceImpl implements ModelResource {
 					throw new IDempiereRestException("Invalid rest view name", "No match found for rest view name: " + tableName, Status.NOT_FOUND);
 			}
 			
-			RestUtils.getTableAndCheckAccess(tableName, false);
+			//	Normalize to AD_Table.TableName as the model class lookup is case sensitive
+			tableName = RestUtils.getTableAndCheckAccess(tableName, false).getTableName();
 
 			String[] includes = null;
 			if (!Util.isEmpty(multiProperty, true)) {
@@ -344,7 +345,8 @@ public class ModelResourceImpl implements ModelResource {
 					throw new IDempiereRestException("Invalid rest view name", "No match found for rest view name: " + tableName, Status.NOT_FOUND);
 			}
 			
-			RestUtils.getTableAndCheckAccess(tableName, false);
+			//	Normalize to AD_Table.TableName as the model class lookup is case sensitive
+			tableName = RestUtils.getTableAndCheckAccess(tableName, false).getTableName();
 			ModelHelper modelHelper = new ModelHelper(tableName, filter, order, top, skip, validationRuleID, context, label);
 			if (view != null && !Util.isEmpty(select, true)) {
 				select = toColumnNames(view, select);
@@ -435,6 +437,8 @@ public class ModelResourceImpl implements ModelResource {
 			}
 			
 			MTable table = RestUtils.getTableAndCheckAccess(tableName, true);
+			//	Normalize to AD_Table.TableName as the model class lookup is case sensitive
+			tableName = table.getTableName();
 
 			if (threadLocalTrxName == null)
 				trx.start();
@@ -560,6 +564,8 @@ public class ModelResourceImpl implements ModelResource {
 			}
 
 			if (childTable != null && childTable.getAD_Table_ID() > 0) {
+				//	Normalize to AD_Table.TableName as the model class lookup is case sensitive
+				childTableName = childTable.getTableName();
 				IPOSerializer childSerializer = IPOSerializer.getPOSerializer(childTableName, MTable.getClass(childTableName));
 				JsonArray fieldArray = fieldElement.getAsJsonArray();
 				JsonArray savedArray = new JsonArray();
@@ -671,7 +677,10 @@ public class ModelResourceImpl implements ModelResource {
 				trx.start();
 			Gson gson = new GsonBuilder().create();
 			JsonObject jsonObject = gson.fromJson(jsonText, JsonObject.class);
-			IPOSerializer serializer = IPOSerializer.getPOSerializer(tableName, MTable.getClass(tableName));
+			//	Normalize to AD_Table.TableName as the model class lookup is case sensitive.
+			//	tableName is captured by a lambda below, so a separate local is used here.
+			String modelTableName = po.get_TableName();
+			IPOSerializer serializer = IPOSerializer.getPOSerializer(modelTableName, MTable.getClass(modelTableName));
 			po = serializer.fromJson(jsonObject, po, view, trx.getTrxName());			
 			po.set_TrxName(trx.getTrxName());
 
@@ -732,8 +741,10 @@ public class ModelResourceImpl implements ModelResource {
 						if (childView == null)
 							continue;
 					}
-					String childTableName = childView != null ? MTable.getTableName(Env.getCtx(), childView.getAD_Table_ID()) : field;
-					MTable childTable = MTable.get(Env.getCtx(), childTableName);
+					String requestedChildTableName = childView != null ? MTable.getTableName(Env.getCtx(), childView.getAD_Table_ID()) : field;
+					MTable childTable = MTable.get(Env.getCtx(), requestedChildTableName);
+					//	Normalize to AD_Table.TableName as the model class lookup is case sensitive
+					String childTableName = childTable != null ? childTable.getTableName() : requestedChildTableName;
 					if (!RestUtils.isValidDetailTable(childTable, RestUtils.getKeyColumnName(po.get_TableName()))) {
 						throw new IDempiereRestException("Wrong detail", "Cannot create/update detail records for the table because it has no column that links to the parent table: " + childTableName, Status.INTERNAL_SERVER_ERROR);
 					}


### PR DESCRIPTION
Fixes #532

### What

The `models` endpoints resolve the table **case-insensitively** (`MTable.get` uses `equalsIgnoreCase`, then `WHERE UPPER(TableName)=?`) but passed the caller's **raw path segment** on to `MTable.getClass()`, which derives a Java class name from that exact string and is case-**sensitive**.

This normalizes to `AD_Table.TableName` at each entry point, so the case-insensitive acceptance the endpoints already offer is carried through consistently.

### Why

On a case-insensitive filesystem with exploded-directory bundles — i.e. an Eclipse PDE launch on macOS (APFS) or Windows (NTFS) — the wrong-case class file is found on disk by Equinox's `ClasspathManager` and then rejected by the JVM:

```
java.lang.NoClassDefFoundError: org/.../MHandlingUnit (wrong name: org/.../Mhandlingunit)
  at java.base/java.lang.ClassLoader.defineClass1(Native Method)
  ...
  at org.adempiere.base.DefaultModelFactory.getPOclass(DefaultModelFactory.java:229)
  at org.compiere.model.MTable.getClass(MTable.java:239)
  at ...ModelResourceImpl.create(...)
```

`NoClassDefFoundError` is a `LinkageError`, not an `Exception`, so it escapes the resource method's `catch (Exception ex)` and the caller receives a bare Jersey 500 rather than a structured error response.

On a case-sensitive filesystem, or from a JAR bundle on any OS, the lookup misses cleanly and returns `null` — so **deployed servers are unaffected**, and this has been invisible to anyone developing on Linux. Issue #532 has the full analysis, including why the API's own lowercased `model-name` output makes non-canonical input a normal client behaviour rather than a typo.

### Call sites changed

| Method | Line | Change |
|---|---|---|
| `getPO` | 169 | capture and use the returned `MTable`'s name |
| `getPOs` | 348 | capture and use the returned `MTable`'s name |
| `create` | 444 | use `table.getTableName()` |
| `createChild` | 576 | use `childTable.getTableName()` |
| `update` | 686 | new local from `po.get_TableName()` |
| `updateChild` | 749 | single-assignment local from `childTable.getTableName()` |

In `update` and `updateChild` the existing variable is captured by a lambda further down (`RestUtils.getKeyColumnName(tableName)` and `loadPO(childTableName, …)` inside `fieldArray.forEach`), so reassigning it would break the effectively-final requirement. A separate single-assignment local is introduced in those two cases rather than restructuring the lambdas.

### Compatibility

No behaviour change for callers already using the canonical casing — `getTableName()` returns the same string that came in. PO instantiation is unaffected either way, since `DefaultPOSerializer.fromJson` builds the PO via `table.getPO(...)`, which already resolves the class from the canonical name.

### Testing

- [x] Reproduced the original failure via `POST /api/v1/models/m_handlingunit` in an Eclipse PDE launch on macOS, with the stack trace above
- [x] Verified the effectively-final constraints at all six sites (this caught a compile error in an earlier revision of the patch)
- [x] No whitespace-only changes — `git diff` and `git diff -w` report identical stats
- [ ] **Not built locally.** I only have an iDempiere 10 P2 target platform available; `master` here targets 12 and uses v12-only core APIs, so a local Tycho build fails for unrelated reasons. Would appreciate CI confirming, or guidance on the expected target platform for contributors.
- [ ] No unit test added — happy to add one to `com.trekglobal.idempiere.rest.api.test` if you'd like a regression test for this.

### Related

The deeper cause sits in core: `DefaultModelFactory.getPOclass` catches `Exception` but not `LinkageError`, so `NoClassDefFoundError` escapes instead of degrading to `null`. Any caller of `MTable.getClass()` with a non-canonical name is exposed, not just REST. A `catch (Exception | LinkageError e)` there would make this class of failure impossible — deliberately *not* `catch (Throwable)`, so JVM errors such as `OutOfMemoryError` still propagate. Happy to raise that separately against iDempiere core if you agree it's worth doing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved REST API consistency by recognizing model and child-table names in their canonical forms.
  - Improved reliability for retrieving, listing, creating, and updating records, including nested child records.
  - Resolved issues where alternate table-name formatting could prevent successful model or child-record lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->